### PR TITLE
chore: jsonapi: require data only for GET and POST

### DIFF
--- a/jsonapi.yaml
+++ b/jsonapi.yaml
@@ -22,11 +22,11 @@ rules:
 
   ### Structure of 200 responses
 
-  jsonapi-response-data:
+  jsonapi-get-post-response-data:
     description: JSON:API response schema requires data property
     message: '{{description}}'
     severity: error
-    given: $.paths[?(!@property.match(/\/openapi/))][*].responses[?(@property.match(/200|201/))].content['application/vnd.api+json']
+    given: $.paths[?(!@property.match(/\/openapi/))][?(@property.match(/get|post/))].responses[?(@property.match(/200|201/))].content['application/vnd.api+json']
     then:
       function: assertObjectPath
       functionOptions:
@@ -42,11 +42,11 @@ rules:
       functionOptions:
         path: [schema, properties, jsonapi, type]
 
-  jsonapi-response-data-schema:
+  jsonapi-get-post-response-data-schema:
     description: JSON:API response data schema
     message: "{{error}}"
     severity: error
-    given: $.paths[?(!@property.match(/\/openapi/))][*].responses[?(@property.match(/200|201/))].content['application/vnd.api+json'].schema.properties
+    given: $.paths[?(!@property.match(/\/openapi/))][?(@property.match(/get|post/))].responses[?(@property.match(/200|201/))].content['application/vnd.api+json'].schema.properties
     then:
       field: data
       function: schema

--- a/tests/fixtures/valid.yaml
+++ b/tests/fixtures/valid.yaml
@@ -344,6 +344,58 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
+    delete:
+      description: Delete a result from the hello-world example
+      operationId: helloWorldDelete
+      parameters:
+      - $ref: '#/components/parameters/Version'
+      - description: The id of the hello-world example entity to be deleted.
+        in: path
+        name: hello_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/vnd.api+json:
+              schema:
+                additionalProperties: false
+                properties:
+                  jsonapi:
+                    $ref: '#/components/schemas/JsonApi'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required:
+                - jsonapi
+                - links
+                type: object
+          description: A hello world entity was deleted
+          headers:
+            deprecation:
+              $ref: '#/components/headers/DeprecationHeader'
+            snyk-request-id:
+              $ref: '#/components/headers/RequestIdResponseHeader'
+            snyk-version-lifecycle-stage:
+              $ref: '#/components/headers/VersionStageResponseHeader'
+            snyk-version-requested:
+              $ref: '#/components/headers/VersionRequestedResponseHeader'
+            snyk-version-served:
+              $ref: '#/components/headers/VersionServedResponseHeader'
+            sunset:
+              $ref: '#/components/headers/SunsetHeader'
+            x-envoy-to-remove-normalized-request-path:
+              $ref: '#/components/headers/InternalGlooNormalizedPathHeader'
+        "default":
+          $ref: '#/components/responses/400'
+        "400":
+          $ref: '#/components/responses/400'
+        "401":
+          $ref: '#/components/responses/401'
+        "404":
+          $ref: '#/components/responses/404'
+        "500":
+          $ref: '#/components/responses/500'
   /org/{org_id}/sarif:
     get:
       description: Get a SARIF document for the org

--- a/tests/jsonapiSchema.test.js
+++ b/tests/jsonapiSchema.test.js
@@ -17,7 +17,7 @@ it('fails on version schema rules', async () => {
   expect(result).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        code: 'jsonapi-response-data-schema',
+        code: 'jsonapi-get-post-response-data-schema',
         message: '"properties" property must have required property "id"',
         path: [
           'paths',
@@ -34,7 +34,7 @@ it('fails on version schema rules', async () => {
         ],
       }),
       expect.objectContaining({
-        code: 'jsonapi-response-data-schema',
+        code: 'jsonapi-get-post-response-data-schema',
         message: '"data" property must have required property "properties"',
         path: [
           'paths',
@@ -50,7 +50,7 @@ it('fails on version schema rules', async () => {
         ],
       }),
       expect.objectContaining({
-        code: 'jsonapi-response-data-schema',
+        code: 'jsonapi-get-post-response-data-schema',
         message: '"properties.data" property must exist',
         path: [
           'paths',
@@ -78,7 +78,7 @@ it('fails on version schema rules', async () => {
         ],
       }),
       expect.objectContaining({
-        code: 'jsonapi-response-data',
+        code: 'jsonapi-get-post-response-data',
         message: 'JSON:API response schema requires data property',
         path: [
           'paths',


### PR DESCRIPTION
According to the JSON API spec, PATCH and DELETE can respond without a
data element. This refines the rules to only require a data element for
GET and POST responses.