### PR TITLE
feat: limits post responses to 201 success code

### DIFF
--- a/jsonapi.yaml
+++ b/jsonapi.yaml
@@ -4,7 +4,6 @@ functions:
   - assertObjectPath
 
 rules:
-
   # JSON:API
 
   ## Content type
@@ -44,7 +43,7 @@ rules:
 
   jsonapi-get-post-response-data-schema:
     description: JSON:API response data schema
-    message: "{{error}}"
+    message: '{{error}}'
     severity: error
     given: $.paths[?(!@property.match(/\/openapi/))][?(@property.match(/get|post/))].responses[?(@property.match(/200|201/))].content['application/vnd.api+json'].schema.properties
     then:
@@ -107,7 +106,17 @@ rules:
                       required: [type]
                   required: [id, type]
               required: [properties]
-  
+
+  jsonapi-post-response-201:
+    description: 'Post responses must respond with a 201 status code on success'
+    severity: error
+    given: $.paths[*].post.responses
+    then:
+      - field: '@key'
+        function: pattern
+        functionOptions:
+          match: '^201|[3-5][0-9]{2}$'
+
   ### JsonApi schema
 
   ### Links schema

--- a/tests/fixtures/jsonapiSchema.fail.yaml
+++ b/tests/fixtures/jsonapiSchema.fail.yaml
@@ -1,52 +1,9 @@
+info:
+  title: Registry
+  version: 3.0.0
+openapi: 3.0.3
+
 components:
-  headers:
-    DeprecationHeader:
-      description: |
-        A header containing the deprecation date of the underlying endpoint. For more information, please refer to the deprecation header RFC:
-        https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html
-      schema:
-        format: date-time
-        type: string
-    InternalGlooNormalizedPathHeader:
-      description: |
-        An internal header used by Snyk's API-Gateway for analytics.
-      schema:
-        type: string
-    RequestIdResponseHeader:
-      description: |
-        A header containing a unique id used for tracking this request. If you are reporting an issue to Snyk it's very helpful to provide this ID.
-      schema:
-        format: uuid
-        type: string
-    SunsetHeader:
-      description: |
-        A header containing the date of when the underlying endpoint will be removed. This header is only present if the endpoint has been deprecated. Please refer to the RFC for more information:
-        https://datatracker.ietf.org/doc/html/rfc8594
-      schema:
-        format: date-time
-        type: string
-    VersionRequestedResponseHeader:
-      description: A header containing the version of the endpoint requested by the
-        caller.
-      schema:
-        $ref: '#/components/schemas/Version'
-    VersionServedResponseHeader:
-      description: A header containing the version of the endpoint that was served
-        by the API.
-      schema:
-        $ref: '#/components/schemas/Version'
-    VersionStageResponseHeader:
-      description: |
-        A header containing the version stage of the endpoint. This stage describes the guarantees snyk provides surrounding stability of the endpoint.
-      schema:
-        enum:
-        - wip
-        - experimental
-        - beta
-        - ga
-        - deprecated
-        - sunset
-        type: string
   parameters:
     Version:
       description: The requested version of the endpoint to process the request
@@ -55,214 +12,23 @@ components:
       required: true
       schema:
         type: string
-  responses:
-    "400":
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: '#/components/schemas/ErrorDocument'
-      description: 'Bad Request: A parameter provided as a part of the request was
-        invalid.'
-      headers:
-        deprecation:
-          $ref: '#/components/headers/DeprecationHeader'
-        snyk-request-id:
-          $ref: '#/components/headers/RequestIdResponseHeader'
-        snyk-version-lifecycle-stage:
-          $ref: '#/components/headers/VersionStageResponseHeader'
-        snyk-version-requested:
-          $ref: '#/components/headers/VersionRequestedResponseHeader'
-        snyk-version-served:
-          $ref: '#/components/headers/VersionServedResponseHeader'
-        sunset:
-          $ref: '#/components/headers/SunsetHeader'
-    "401":
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: '#/components/schemas/ErrorDocument'
-      description: 'Unauthorized: the request requires an authentication token or
-        a token with more permissions.'
-      headers:
-        deprecation:
-          $ref: '#/components/headers/DeprecationHeader'
-        snyk-request-id:
-          $ref: '#/components/headers/RequestIdResponseHeader'
-        snyk-version-lifecycle-stage:
-          $ref: '#/components/headers/VersionStageResponseHeader'
-        snyk-version-requested:
-          $ref: '#/components/headers/VersionRequestedResponseHeader'
-        snyk-version-served:
-          $ref: '#/components/headers/VersionServedResponseHeader'
-        sunset:
-          $ref: '#/components/headers/SunsetHeader'
-    "404":
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: '#/components/schemas/ErrorDocument'
-      description: 'Not Found: The resource being operated on could not be found.'
-      headers:
-        deprecation:
-          $ref: '#/components/headers/DeprecationHeader'
-        snyk-request-id:
-          $ref: '#/components/headers/RequestIdResponseHeader'
-        snyk-version-lifecycle-stage:
-          $ref: '#/components/headers/VersionStageResponseHeader'
-        snyk-version-requested:
-          $ref: '#/components/headers/VersionRequestedResponseHeader'
-        snyk-version-served:
-          $ref: '#/components/headers/VersionServedResponseHeader'
-        sunset:
-          $ref: '#/components/headers/SunsetHeader'
-    "500":
-      content:
-        application/vnd.api+json:
-          schema:
-            $ref: '#/components/schemas/ErrorDocument'
-      description: 'Internal Server Error: An error was encountered while attempting
-        to process the request.'
-      headers:
-        deprecation:
-          $ref: '#/components/headers/DeprecationHeader'
-        snyk-request-id:
-          $ref: '#/components/headers/RequestIdResponseHeader'
-        snyk-version-lifecycle-stage:
-          $ref: '#/components/headers/VersionStageResponseHeader'
-        snyk-version-requested:
-          $ref: '#/components/headers/VersionRequestedResponseHeader'
-        snyk-version-served:
-          $ref: '#/components/headers/VersionServedResponseHeader'
-        sunset:
-          $ref: '#/components/headers/SunsetHeader'
+
   schemas:
-    Error:
-      additionalProperties: false
-      properties:
-        detail:
-          type: string
-        id:
-          format: uuid
-          type: string
-        meta:
-          additionalProperties: true
-          type: object
-        source:
-          additionalProperties: false
-          properties:
-            parameter:
-              type: string
-            pointer:
-              type: string
-          type: object
-        status:
-          type: string
-      required:
-      - status
-      - detail
-      type: object
-    ErrorDocument:
-      additionalProperties: false
-      properties:
-        errors:
-          items:
-            $ref: '#/components/schemas/Error'
-          minItems: 1
-          type: array
-        JsonApi:
-          $ref: '#/components/schemas/JSONAPI'
-      required:
-      - JsonApi
-      - errors
-      type: object
-    HelloWorld:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties: false
-          properties:
-            deprecatedField:
-              type: string
-            message:
-              type: string
-            requestSubject:
-              additionalProperties: false
-              properties:
-                clientId:
-                  format: uuid
-                  type: string
-                publicId:
-                  format: uuid
-                  type: string
-                type:
-                  type: string
-              required:
-              - publicId
-              - type
-              type: object
-          required:
-          - message
-          - deprecatedField
-          - requestSubject
-          type: object
-        id:
-          format: uuid
-          type: string
-        type:
-          type: string
-      required:
-      - type
-      - id
-      - attributes
-      type: object
     JSONAPI:
       additionalProperties: false
       properties:
         version:
           type: string
       required:
-      - version
+        - version
       type: object
-    LinkProperty:
-      oneOf:
-      - type: string
-      - additionalProperties: false
-        properties:
-          href:
-            type: string
-          meta:
-            additionalProperties: true
-            type: object
-        required:
-        - href
-        - meta
-        type: object
-    Links:
-      additionalProperties: false
-      properties:
-        first:
-          $ref: '#/components/schemas/LinkProperty'
-        last:
-          $ref: '#/components/schemas/LinkProperty'
-        next:
-          $ref: '#/components/schemas/LinkProperty'
-        prev:
-          $ref: '#/components/schemas/LinkProperty'
-        related:
-          $ref: '#/components/schemas/LinkProperty'
-        self:
-          $ref: '#/components/schemas/LinkProperty'
-      type: object
-info:
-  title: Registry
-  version: 3.0.0
-openapi: 3.0.3
+
 paths:
   /goof/no-params-no-headers:
     get:
       operationId: goofNoParamsNoHeaders
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -273,7 +39,7 @@ paths:
       parameters: []
       operationId: goofNoVersion
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -284,7 +50,7 @@ paths:
     get:
       operationId: badResponseSchemaType
       responses:
-        "200":
+        '200':
           content:
             application/vnd.api+json:
               schema:
@@ -294,7 +60,7 @@ paths:
     get:
       operationId: missingDataId
       responses:
-        "200":
+        '200':
           content:
             application/vnd.api+json:
               schema:
@@ -310,7 +76,7 @@ paths:
     get:
       operationId: dataIdNotUuid
       responses:
-        "200":
+        '200':
           content:
             application/vnd.api+json:
               schema:
@@ -323,7 +89,7 @@ paths:
     get:
       operationId: dataMissingAttributes
       responses:
-        "200":
+        '200':
           content:
             application/vnd.api+json:
               schema:
@@ -339,7 +105,7 @@ paths:
     get:
       operationId: dataMissingAttributes
       responses:
-        "200":
+        '200':
           content:
             application/vnd.api+json:
               schema:
@@ -354,7 +120,28 @@ paths:
                       foo:
                         type: string
 
-    x-snyk-api-version: "2021-06-01"
+  /goof/bad_post_status_code:
+    post:
+      description: 'test'
+      operationId: dataNoPost201
+      parameters:
+        - $ref: '#/components/parameters/Version'
+      responses:
+        '200':
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  attributes:
+                    type: object
+                    properties:
+                      foo:
+                        type: string
+
 servers:
-- description: Snyk Registry
-  url: /api/v3
+  - description: Snyk Registry
+    url: /api/v3

--- a/tests/fixtures/valid.yaml
+++ b/tests/fixtures/valid.yaml
@@ -8,6 +8,8 @@ tags:
     description: A hello world example
   - name: Hello World delete
     description: A hello world example
+  - name: Hello World post
+    description: A hello world example
   - name: Issue Summaries
     description: aaa
   - name: SARIF
@@ -403,6 +405,72 @@ paths:
           $ref: '#/components/responses/404'
         '500':
           $ref: '#/components/responses/500'
+
+    post:
+      description: Create a single result from the hello_world example
+      operationId: helloWorldCreate
+      tags:
+        - Hello World post
+      parameters:
+        - $ref: '#/components/parameters/Version'
+        - name: hello_id
+          in: path
+          description: The id of the hello-world example entity to be retrieved.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                attributes:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    betaField:
+                      type: string
+                  additionalProperties: false
+                  required: ['message', 'betaField']
+              additionalProperties: false
+              required: ['attributes']
+      responses:
+        '201':
+          description: A hello world entity being requested is returned
+          headers:
+            deprecation:
+              $ref: '#/components/headers/DeprecationHeader'
+            snyk-request-id:
+              $ref: '#/components/headers/RequestIdResponseHeader'
+            snyk-version-lifecycle-stage:
+              $ref: '#/components/headers/VersionStageResponseHeader'
+            snyk-version-requested:
+              $ref: '#/components/headers/VersionRequestedResponseHeader'
+            snyk-version-served:
+              $ref: '#/components/headers/VersionServedResponseHeader'
+            sunset:
+              $ref: '#/components/headers/SunsetHeader'
+            x-envoy-to-remove-normalized-request-path:
+              $ref: '#/components/headers/InternalGlooNormalizedPathHeader'
+          content:
+            application/vnd.api+json:
+              schema:
+                additionalProperties: false
+                properties:
+                  data:
+                    $ref: '#/components/schemas/HelloWorld'
+                  jsonapi:
+                    $ref: '#/components/schemas/JsonApi'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required:
+                  - jsonapi
+                  - data
+                  - links
+                type: object
+
     delete:
       description: Delete a result from the hello-world example
       operationId: helloWorldDelete

--- a/tests/jsonapiSchema.test.js
+++ b/tests/jsonapiSchema.test.js
@@ -90,6 +90,18 @@ it('fails on version schema rules', async () => {
           'application/vnd.api+json',
         ],
       }),
+      expect.objectContaining({
+        code: 'jsonapi-post-response-201',
+        message:
+          'Post responses must respond with a 201 status code on success',
+        path: [
+          'paths',
+          '/goof/bad_post_status_code',
+          'post',
+          'responses',
+          '200',
+        ],
+      }),
     ]),
   );
 });


### PR DESCRIPTION
We expect our POST endpoints to be creation endpoints, and so the response should be a 201 and supply an ID (which is caught by another rule).
This rule limits the spec to being _only_ 201, as it seems possible to allow many 2xx responses.
Outside of the 2xx range I've been pretty open with the ranges being 3xx, 4xx and 5xx.