### PR TITLE
feat: lint for exanples or enum fields on responses

### DIFF
--- a/apinext.yaml
+++ b/apinext.yaml
@@ -55,3 +55,27 @@ rules:
         functionOptions:
           values:
             - uuid
+
+  # Require Examples for user defined response objects - in an array
+  apinext-operation-response-array-examples:
+    description: Responses must have an enum or examples field and be non-empty
+    severity: error
+    given: $.paths[*][*].responses[*].content[*].schema.properties.data.items.properties.attributes..[properties][?(@.type !== 'object')]
+    then:
+      function: xor
+      functionOptions:
+        properties:
+          - enum
+          - example
+
+  # Require Examples for user defined response objects - single objects
+  apinext-operation-response-single-examples:
+    description: Responses must have an enum or examples field and be non-empty
+    severity: error
+    given: $.paths[*][*].responses[*].content[*].schema.properties.data.properties.attributes..[properties][?(@.type !== 'object')]
+    then:
+      function: xor
+      functionOptions:
+        properties:
+          - enum
+          - example

--- a/tests/examplesExist.test.js
+++ b/tests/examplesExist.test.js
@@ -1,0 +1,64 @@
+const { Spectral } = require('@stoplight/spectral-core');
+const { loadRules, loadSpec } = require('./utils');
+
+let rules;
+
+beforeAll(async () => {
+  rules = await loadRules('apinext.yaml');
+});
+
+it('fails on no enum or examples fields', async () => {
+  const spectral = new Spectral();
+  spectral.setRuleset(rules);
+  const result = await spectral.run(loadSpec('fixtures/noExamples.fail.yaml'));
+  expect(result).not.toHaveLength(0);
+  expect(result).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        code: 'apinext-operation-response-array-examples',
+        message:
+          'Responses must have an enum or examples field and be non-empty',
+        path: [
+          'paths',
+          '/orgs/{org_id}/returns_array',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.api+json',
+          'schema',
+          'properties',
+          'data',
+          'items',
+          'properties',
+          'attributes',
+          'properties',
+          'issueType',
+        ],
+      }),
+      expect.objectContaining({
+        code: 'apinext-operation-response-single-examples',
+        message:
+          'Responses must have an enum or examples field and be non-empty',
+        path: [
+          'paths',
+          '/orgs/{org_id}/returns_single',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.api+json',
+          'schema',
+          'properties',
+          'data',
+          'properties',
+          'attributes',
+          'allOf',
+          '1',
+          'properties',
+          'fingerprint',
+        ],
+      }),
+    ]),
+  );
+});

--- a/tests/fixtures/noExamples.fail.yaml
+++ b/tests/fixtures/noExamples.fail.yaml
@@ -1,0 +1,173 @@
+info:
+  title: Registry
+  version: 3.0.0
+openapi: 3.0.3
+
+servers:
+  - description: Snyk Registry
+    url: /api/v3
+
+components:
+  schemas:
+    IssueSummary:
+      type: object
+      description: Summary description of an issue.
+      properties:
+        type:
+          type: string
+          description: Content type
+          example: 'issue-summary'
+        id:
+          type: string
+          description: The Issue ID
+          format: uuid
+          example: '2bcd80a9-e343-4601-9393-f820d51ab713'
+        attributes:
+          type: object
+          properties:
+            issueType:
+              type: string
+              description: >
+                Issue type. Implies the existence of a resource
+                /issues/detail/{issue-type}/{id}.
+            title:
+              type: string
+              description: The name of the issue
+              example: a title
+            severity:
+              type: string
+              description: Severity of an issue
+              enum:
+                - low
+                - medium
+                - high
+                - critical
+            ignored:
+              type: boolean
+              description: Whether the issue has been ignored
+              example: true
+          required: ['issueType', 'title', 'severity', 'ignored']
+        links:
+          $ref: '#/components/schemas/Links'
+      required: ['type', 'id', 'attributes', 'links']
+    LinkProperty:
+      oneOf:
+        - type: string
+        - additionalProperties: false
+          properties:
+            href:
+              type: string
+              example: thing
+            meta:
+              additionalProperties: true
+              type: object
+          required:
+            - href
+            - meta
+          type: object
+    Links:
+      additionalProperties: false
+      properties:
+        first:
+          $ref: '#/components/schemas/LinkProperty'
+        last:
+          $ref: '#/components/schemas/LinkProperty'
+        next:
+          $ref: '#/components/schemas/LinkProperty'
+        prev:
+          $ref: '#/components/schemas/LinkProperty'
+        related:
+          $ref: '#/components/schemas/LinkProperty'
+        self:
+          $ref: '#/components/schemas/LinkProperty'
+      type: object
+
+paths:
+  /orgs/{org_id}/returns_array:
+    get:
+      operationId: returnsArray
+      description: >
+        Get a summary of issues on a project or snapshot. Supports
+        pagination, filtering by severity and issue type.
+        ProjectID must be specified.
+      parameters:
+        - name: org_id
+          in: path
+          required: true
+          description: The id of the group to return a list of issues for
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: '#/components/schemas/IssueSummary' }
+                  jsonapi:
+                    $ref: '#/components/schemas/JsonApi'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required: ['jsonapi', 'data', 'links']
+
+  /orgs/{org_id}/returns_single:
+    get:
+      operationId: returnsSingle
+      description: >
+        Get a summary of issues on a project or snapshot. Supports
+        pagination, filtering by severity and issue type.
+        ProjectID must be specified.
+      parameters:
+        - name: org_id
+          in: path
+          required: true
+          description: The id of the group to return a list of issues for
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    description: An issue discovered by SAST code analysis
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        description: Code public issue ID
+                        example: 'ea536a06-0566-40ca-b96b-155568aa2027'
+                      type:
+                        type: string
+                        description: Content type
+                        example: 'code-issue'
+                      attributes:
+                        allOf:
+                          - $ref: './issue-summary.yaml#/IssueSummaryAttributes'
+                          - type: object
+                            properties:
+                              fingerprint:
+                                type: string
+                                nullable: true
+                              fingerprintVersion:
+                                type: string
+                                nullable: true
+                              priorityScoreFactors:
+                                type: array
+                                description: Descriptions of factors affecting priority score
+                                items:
+                                  type: string
+                    required: ['type', 'id', 'attributes']
+                  jsonapi:
+                    $ref: '#/components/schemas/JsonApi'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required: ['jsonapi', 'data', 'links']

--- a/tests/fixtures/valid.yaml
+++ b/tests/fixtures/valid.yaml
@@ -229,23 +229,28 @@ components:
           properties:
             deprecatedField:
               type: string
+              example: test
             message:
               type: string
+              example: my message
             requestSubject:
+              type: object
               additionalProperties: false
               properties:
                 clientId:
                   format: uuid
                   type: string
+                  example: '2bcd80a9-e343-4601-9393-f820d51ab713'
                 publicId:
                   format: uuid
                   type: string
+                  example: '2bcd80a9-e343-4601-9393-f820d51ab713'
                 type:
                   type: string
+                  example: my_type
               required:
                 - publicId
                 - type
-              type: object
           required:
             - message
             - deprecatedField
@@ -254,8 +259,10 @@ components:
         id:
           format: uuid
           type: string
+          example: '2bcd80a9-e343-4601-9393-f820d51ab713'
         type:
           type: string
+          example: hello_world
       required:
         - type
         - id
@@ -286,6 +293,7 @@ components:
             title:
               type: string
               description: The name of the issue
+              example: a title
             severity:
               type: string
               description: Severity of an issue
@@ -297,6 +305,7 @@ components:
             ignored:
               type: boolean
               description: Whether the issue has been ignored
+              example: true
           required: ['issueType', 'title', 'severity', 'ignored']
         links:
           $ref: '#/components/schemas/Links'
@@ -316,6 +325,7 @@ components:
           properties:
             href:
               type: string
+              example: thing
             meta:
               additionalProperties: true
               type: object


### PR DESCRIPTION
This is a tricky one to path for. We want to get the properties fields of objects, but not _all_ fields, which involved some recursive pathing. But filtering isn’t flexible enough in some cases. So I had to get... creative.