### PR TITLE
feat: standardize pagination params and links

### DIFF
--- a/functions/arrayObjectPattern.js
+++ b/functions/arrayObjectPattern.js
@@ -1,10 +1,9 @@
-const camelCaseRegex = /^([a-z]+([A-Z][a-z]+)*)$/;
-
-module.exports = (targetVal, opts, context) => {
+module.exports = (targetVal, opts) => {
   const re = new RegExp(opts.match);
   const result = targetVal.filter((item) => {
     return item[opts.field].match(re);
   });
+
   if (!result || result.length === 0) {
     return [
       {

--- a/functions/contains.js
+++ b/functions/contains.js
@@ -1,0 +1,14 @@
+module.exports = (targetVal, opts) => {
+  const { field, values } = opts;
+  const fieldArray = targetVal.map((item) => item[field]);
+
+  for (const value of values) {
+    if (!fieldArray.includes(value)) {
+      return [
+        {
+          message: `Array must include {value}.`,
+        },
+      ];
+    }
+  }
+};

--- a/functions/notContains.js
+++ b/functions/notContains.js
@@ -1,0 +1,14 @@
+module.exports = (targetVal, opts) => {
+  const { field, values } = opts;
+  const fieldArray = targetVal.map((item) => item[field]);
+
+  for (const value of values) {
+    if (fieldArray.includes(value)) {
+      return [
+        {
+          message: `Array must not include {value}.`,
+        },
+      ];
+    }
+  }
+};

--- a/jsonapi.yaml
+++ b/jsonapi.yaml
@@ -2,6 +2,8 @@
 
 functions:
   - assertObjectPath
+  - contains
+  - notContains
 
 rules:
   # JSON:API
@@ -166,15 +168,15 @@ rules:
   jsonapi-created-response-location:
     description: Post responses must include a location header for the created resource
     severity: error
-    given: $.paths[*].post.responses.'201'.headers
+    given: $.paths[*].post.responses.201.headers
     then:
       field: location
       function: truthy
 
   jsonapi-created-response-self-link:
-    description: Post responses must include a location header for the created resource
+    description: Post responses must include a self link for the created resource
     severity: error
-    given: $.paths[*].post.responses.'201'.content.'application/vnd.api+json'.schema.properties.data.properties.links
+    given: $.paths[*].post.responses.201.content['application/vnd.api+json'].schema.properties.data.properties.links.properties
     then:
       field: self
       function: truthy
@@ -218,6 +220,36 @@ rules:
   # TODO: Add rule to check location header link matches self link in response body (on response validation, how to test that?) 
 
   ### JsonApi schema
+
+  ### Collections
+
+  jsonapi-pagination-collection-parameters:
+    description: Collection requests must include pagination parameters
+    severity: error
+    given: $.paths[?(!@property.match(/\/openapi/) && !@property.match(/\{[a-z]*?_?id\}$/))].get.parameters
+    then:
+      function: contains
+      functionOptions:
+        field: name
+        values: [starting_after, ending_before, limit]
+
+  jsonapi-pagination-collection-links:
+    description: Responses for collection requests must include pagination links
+    severity: error
+    given: $.paths[?(!@property.match(/\/openapi/) && !@property.match(/\{[a-z]*?_?id\}$/))].get.responses.200.content['application/vnd.api+json'].schema.properties
+    then:
+      field: links
+      function: truthy
+
+  jsonapi-no-pagination-parameters:
+    description: Non-GET requests should not allow pagination parameters
+    severity: error
+    given: $.paths[*][?(@property.match(/post|patch|delete/))].parameters
+    then:
+      function: notContains
+      functionOptions:
+        field: name
+        values: [starting_after, ending_before, limit]
 
   ### Links schema
 

--- a/tests/fixtures/jsonapiSchema.fail.yaml
+++ b/tests/fixtures/jsonapiSchema.fail.yaml
@@ -16,6 +16,12 @@ components:
       required: true
       schema:
         type: string
+    StartingAfter:
+      description: Return the page of results immediately after this cursor
+      in: query
+      name: starting_after
+      schema:
+        type: string
 
   schemas:
     JSONAPI:

--- a/tests/jsonapiSchema.test.js
+++ b/tests/jsonapiSchema.test.js
@@ -1,205 +1,343 @@
 const { Spectral } = require('@stoplight/spectral-core');
 const { loadRules, loadSpec } = require('./utils');
 
-let rules;
+const openApiDocument = `
+info:
+  title: Registry
+  version: 3.0.0
+openapi: 3.0.3
 
-beforeAll(async () => {
-  rules = await loadRules('jsonapi.yaml');
-});
+servers:
+  - description: Snyk Registry
+    url: /api/v3
+`;
+const rulesetComponents = `
+components:
+  parameters:
+    Version:
+      description: The requested version of the endpoint to process the request
+      in: query
+      name: version
+      required: true
+      schema:
+        type: string
+`;
 
-it('fails on version schema rules', async () => {
-  const spectral = new Spectral();
-  spectral.setRuleset(rules);
-  const result = await spectral.run(
-    loadSpec('fixtures/jsonapiSchema.fail.yaml'),
-  );
-  expect(result).not.toHaveLength(0);
-  expect(result).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        code: 'jsonapi-get-post-response-data-schema',
-        message: '"properties" property must have required property "id"',
-        path: [
-          'paths',
-          '/goof/badJsonApi/missingDataId',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-          'schema',
-          'properties',
-          'data',
-          'properties',
-        ],
-      }),
-      expect.objectContaining({
-        code: 'jsonapi-get-post-response-data-schema',
-        message: '"data" property must have required property "properties"',
-        path: [
-          'paths',
-          '/goof/badJsonApi/dataIdNotUuid',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-          'schema',
-          'properties',
-          'data',
-        ],
-      }),
-      expect.objectContaining({
-        code: 'jsonapi-get-post-response-data-schema',
-        message: '"properties.data" property must exist',
-        path: [
-          'paths',
-          '/goof/badJsonApi/dataMissingType',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-          'schema',
-          'properties',
-        ],
-      }),
-      expect.objectContaining({
-        code: 'jsonapi-response-jsonapi',
-        message: 'JSON:API response schema requires jsonapi property',
-        path: [
-          'paths',
-          '/goof/badJsonApi/dataMissingType',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-        ],
-      }),
-      expect.objectContaining({
-        code: 'jsonapi-get-post-response-data',
-        message: 'JSON:API response schema requires data property',
-        path: [
-          'paths',
-          '/goof/badJsonApi/dataMissingType',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-        ],
-      }),
-      expect.objectContaining({
-        code: 'jsonapi-post-response-201',
-        message:
-          'Post responses must respond with a 201 status code on success',
-        path: [
-          'paths',
-          '/goof/bad_post_status_code',
-          'post',
-          'responses',
-          '200',
-        ],
-      }),
+describe('JSON API Schema', () => {
+  let spectral;
+  let rules;
+  let result;
 
-      expect.objectContaining({
-        code: 'jsonapi-patch-response-data',
-        message: 'JSON:API patch 200 response requires a schema',
-        path: [
-          'paths',
-          '/goof/patch_missing_content',
-          'patch',
-          'responses',
-          '200',
-        ],
-      }),
+  beforeAll(async () => {
+    rules = await loadRules('jsonapi.yaml');
+    spectral = new Spectral();
+    spectral.setRuleset(rules);
+    result = await spectral.run(loadSpec('fixtures/jsonapiSchema.fail.yaml'));
+  });
 
-      expect.objectContaining({
-        code: 'jsonapi-patch-response-200-schema',
-        message: 'Property "anotherField" is not expected to be here',
-        path: [
-          'paths',
-          '/goof/patch_no_meta_only',
-          'patch',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-          'schema',
-          'properties',
-        ],
-      }),
+  it('fails on version schema rules', async () => {
+    expect(result).not.toHaveLength(0);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'jsonapi-get-post-response-data-schema',
+          message: '"properties" property must have required property "id"',
+          path: [
+            'paths',
+            '/goof/badJsonApi/missingDataId',
+            'get',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+            'schema',
+            'properties',
+            'data',
+            'properties',
+          ],
+        }),
+        expect.objectContaining({
+          code: 'jsonapi-get-post-response-data-schema',
+          message: '"data" property must have required property "properties"',
+          path: [
+            'paths',
+            '/goof/badJsonApi/dataIdNotUuid',
+            'get',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+            'schema',
+            'properties',
+            'data',
+          ],
+        }),
+        expect.objectContaining({
+          code: 'jsonapi-get-post-response-data-schema',
+          message: '"properties.data" property must exist',
+          path: [
+            'paths',
+            '/goof/badJsonApi/dataMissingType',
+            'get',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+            'schema',
+            'properties',
+          ],
+        }),
+        expect.objectContaining({
+          code: 'jsonapi-response-jsonapi',
+          message: 'JSON:API response schema requires jsonapi property',
+          path: [
+            'paths',
+            '/goof/badJsonApi/dataMissingType',
+            'get',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+          ],
+        }),
+        expect.objectContaining({
+          code: 'jsonapi-get-post-response-data',
+          message: 'JSON:API response schema requires data property',
+          path: [
+            'paths',
+            '/goof/badJsonApi/dataMissingType',
+            'get',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+          ],
+        }),
+        expect.objectContaining({
+          code: 'jsonapi-post-response-201',
+          message:
+            'Post responses must respond with a 201 status code on success',
+          path: [
+            'paths',
+            '/goof/bad_post_status_code',
+            'post',
+            'responses',
+            '200',
+          ],
+        }),
 
-      expect.objectContaining({
-        code: 'jsonapi-patch-response-200-schema',
-        message: '"properties" property must have required property "meta"',
-        path: [
-          'paths',
-          '/goof/patch_no_data',
-          'patch',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-          'schema',
-          'properties',
-        ],
-      }),
+        expect.objectContaining({
+          code: 'jsonapi-patch-response-data',
+          message: 'JSON:API patch 200 response requires a schema',
+          path: [
+            'paths',
+            '/goof/patch_missing_content',
+            'patch',
+            'responses',
+            '200',
+          ],
+        }),
 
-      expect.objectContaining({
-        code: 'jsonapi-patch-response-204-schema',
-        message: '"content" property must be falsy',
-        path: [
-          'paths',
-          '/goof/patch_no_content',
-          'patch',
-          'responses',
-          '204',
-          'content',
-        ],
-      }),
+        expect.objectContaining({
+          code: 'jsonapi-patch-response-200-schema',
+          message: 'Property "anotherField" is not expected to be here',
+          path: [
+            'paths',
+            '/goof/patch_no_meta_only',
+            'patch',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+            'schema',
+            'properties',
+          ],
+        }),
 
-      expect.objectContaining({
-        code: 'jsonapi-delete-response-statuses',
-        message: 'Delete endpoints can only use 200 or 204 status codes',
-        path: [
-          'paths',
-          '/goof/delete_invalid_status',
-          'delete',
-          'responses',
-          '203',
-        ],
-      }),
+        expect.objectContaining({
+          code: 'jsonapi-patch-response-200-schema',
+          message: '"properties" property must have required property "meta"',
+          path: [
+            'paths',
+            '/goof/patch_no_data',
+            'patch',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+            'schema',
+            'properties',
+          ],
+        }),
 
-      expect.objectContaining({
-        code: 'jsonapi-delete-response-200',
-        message: '"properties" property must have required property "meta"',
-        path: [
-          'paths',
-          '/goof/delete_with_meta',
-          'delete',
-          'responses',
-          '200',
-          'content',
-          'application/vnd.api+json',
-          'schema',
-          'properties',
-        ],
-      }),
+        expect.objectContaining({
+          code: 'jsonapi-patch-response-204-schema',
+          message: '"content" property must be falsy',
+          path: [
+            'paths',
+            '/goof/patch_no_content',
+            'patch',
+            'responses',
+            '204',
+            'content',
+          ],
+        }),
 
-      expect.objectContaining({
-        code: 'jsonapi-delete-response-204',
-        message: '"content" property must be falsy',
-        path: [
-          'paths',
-          '/goof/delete_no_content',
-          'delete',
-          'responses',
-          '204',
-          'content',
-        ],
-      }),
-    ]),
-  );
+        expect.objectContaining({
+          code: 'jsonapi-delete-response-statuses',
+          message: 'Delete endpoints can only use 200 or 204 status codes',
+          path: [
+            'paths',
+            '/goof/delete_invalid_status',
+            'delete',
+            'responses',
+            '203',
+          ],
+        }),
+
+        expect.objectContaining({
+          code: 'jsonapi-delete-response-200',
+          message: '"properties" property must have required property "meta"',
+          path: [
+            'paths',
+            '/goof/delete_with_meta',
+            'delete',
+            'responses',
+            '200',
+            'content',
+            'application/vnd.api+json',
+            'schema',
+            'properties',
+          ],
+        }),
+
+        expect.objectContaining({
+          code: 'jsonapi-delete-response-204',
+          message: '"content" property must be falsy',
+          path: [
+            'paths',
+            '/goof/delete_no_content',
+            'delete',
+            'responses',
+            '204',
+            'content',
+          ],
+        }),
+      ]),
+    );
+  });
+
+  describe('Collection Rules', () => {
+    let ruleSet = '';
+    let validationResults;
+
+    beforeAll(async () => {
+      ruleSet = `
+${openApiDocument}
+${rulesetComponents}
+    StartingAfter:
+      description: Return the page of results immediately after this cursor
+      in: query
+      name: starting_after
+      schema:
+        type: string
+
+paths:
+  /org/{org_id}/collection_pagination_parameters:
+    get:
+      description: 'test'
+      operationId: dataCollectionPaginationParameters
+      parameters:
+        - $ref: '#/components/parameters/Version'
+        - description: Return the page of results immediately after this cursor
+          in: query
+          name: starting_after
+          schema:
+            type: string
+
+  /org/{org_id}/collection_pagination_links:
+    get:
+      description: 'test'
+      parameters:
+        - $ref: '#/components/parameters/Version'
+      responses:
+        '200':
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: '#/components/schemas/Project' }
+                  jsonapi: { $ref: '#/components/schemas/JsonApi' }
+
+  /org/{org_id}/non_get_pagination_parameters:
+    post:
+      description: 'test'
+      parameters:
+        - $ref: '#/components/parameters/Version'
+        - $ref: '#/components/parameters/StartingAfter'
+
+    patch:
+      description: 'test'
+      parameters:
+        - $ref: '#/components/parameters/Version'
+        - $ref: '#/components/parameters/StartingAfter'
+
+    delete:
+      description: 'test'
+      parameters:
+        - $ref: '#/components/parameters/Version'
+        - $ref: '#/components/parameters/StartingAfter'
+      `;
+
+      validationResults = await spectral.run(ruleSet);
+    });
+
+    it('fails on collection pagination rules', () => {
+      expect(validationResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-pagination-collection-parameters',
+            message: 'Collection requests must include pagination parameters',
+            path: [
+              'paths',
+              '/org/{org_id}/collection_pagination_parameters',
+              'get',
+              'parameters',
+            ],
+          }),
+
+          expect.objectContaining({
+            code: 'jsonapi-pagination-collection-links',
+            message:
+              'Responses for collection requests must include pagination links',
+            path: [
+              'paths',
+              '/org/{org_id}/collection_pagination_links',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+              'schema',
+              'properties',
+            ],
+          }),
+
+          expect.objectContaining({
+            code: 'jsonapi-no-pagination-parameters',
+            message: 'Non-GET requests should not allow pagination parameters',
+            path: [
+              'paths',
+              '/org/{org_id}/non_get_pagination_parameters',
+              'post',
+              'parameters',
+            ],
+          }),
+        ]),
+      );
+    });
+  });
 });


### PR DESCRIPTION
Enforce pagination parameters and responses on collection requests.
Prohibit pagination parameters on post/patch/delete endpoints.