### PR TITLE
feat: standardizes approach to having top-level self links

### DIFF
--- a/jsonapi.yaml
+++ b/jsonapi.yaml
@@ -135,7 +135,9 @@ rules:
               properties:
                 meta:
                   type: object
-              required: [meta]
+                links:
+                  type: object
+              required: [meta, links]
               additionalProperties: false
             - type: object
               properties:
@@ -143,7 +145,9 @@ rules:
                   type: object
                 jsonapi:
                   type: object
-              required: [data, jsonapi]
+                links:
+                  type: object
+              required: [data, jsonapi, links]
               additionalProperties: false
   
   jsonapi-patch-response-204-schema:
@@ -258,6 +262,24 @@ rules:
         values: [starting_after, ending_before, limit]
 
   ### Links schema
+
+  jsonapi-self-links-get-patch:
+    description: Successful GET responses should include a top-level self link
+    severity: error
+    given: $.paths[?(!@property.match(/\/openapi/))][?(@property.match(/get|patch/))].responses.200.content['application/vnd.api+json'].schema.properties
+    then:
+      function: assertObjectPath
+      functionOptions:
+        path: [links, properties, self]
+
+  jsonapi-self-links-post:
+    description: Successful GET responses should include a top-level self link
+    severity: error
+    given: $.paths[?(!@property.match(/\/openapi/))].post.responses.201.content['application/vnd.api+json'].schema.properties
+    then:
+      function: assertObjectPath
+      functionOptions:
+        path: [links, properties, self]
 
   ### Relationships
 

--- a/tests/fixtures/jsonapiSchema.fail.yaml
+++ b/tests/fixtures/jsonapiSchema.fail.yaml
@@ -180,6 +180,10 @@ paths:
                       customField:
                         type: string
                         example: 'I have updated!'
+                  links:
+                    type: object
+                    properties:
+                      self: { $ref: '#/components/schemas/LinkProperty' }
                   anotherField:
                     type: object
                 required: [meta]

--- a/tests/fixtures/valid.yaml
+++ b/tests/fixtures/valid.yaml
@@ -679,6 +679,10 @@ paths:
                       customField:
                         type: string
                         example: 'I have updated!'
+                  links:
+                    type: object
+                    properties:
+                      self: { $ref: '#/components/schemas/LinkProperty' }
                 required: [meta]
                 additionalProperties: false
 
@@ -739,6 +743,10 @@ paths:
                 properties:
                   data: { $ref: '#/components/schemas/Project' }
                   jsonapi: { $ref: '#/components/schemas/JsonApi' }
+                  links:
+                    type: object
+                    properties:
+                      self: { $ref: '#/components/schemas/LinkProperty' }
                 required: ['jsonapi', 'data', 'links' ]
                 additionalProperties: false
 
@@ -808,6 +816,10 @@ paths:
                 properties:
                   data: { $ref: '#/components/schemas/Project' }
                   jsonapi: { $ref: '#/components/schemas/JsonApi' }
+                  links:
+                    type: object
+                    properties:
+                      self: { $ref: '#/components/schemas/LinkProperty' }
                 required: ['jsonapi', 'data' ]
                 additionalProperties: false
 
@@ -934,7 +946,12 @@ paths:
                 properties:
                   jsonapi: { $ref: '#/components/schemas/JsonApi' }
                   data: { $ref: '#/components/schemas/OrgInvitation' }
-                required: [jsonapi, data]
+                  links:
+                    type: object
+                    properties:
+                      self: { $ref: '#/components/schemas/LinkProperty' }
+                    required: [self]
+                required: [jsonapi, data, links]
                 additionalProperties: false
     
     patch:

--- a/tests/jsonapiSchema.test.js
+++ b/tests/jsonapiSchema.test.js
@@ -1,5 +1,5 @@
 const { Spectral } = require('@stoplight/spectral-core');
-const { loadRules, loadSpec } = require('./utils');
+const { loadRules, loadSpec, getAllErrors } = require('./utils');
 
 const openApiDocument = {
   openapi: '3.0.3',
@@ -20,205 +20,239 @@ const openApiDocument = {
 describe('JSON API Schema', () => {
   let spectral;
   let rules;
-  let result;
+  let spec;
 
   beforeAll(async () => {
     rules = await loadRules('jsonapi.yaml');
     spectral = new Spectral();
     spectral.setRuleset(rules);
-    result = await spectral.run(loadSpec('fixtures/jsonapiSchema.fail.yaml'));
+    spec = loadSpec('fixtures/jsonapiSchema.fail.yaml');
   });
 
-  it('fails on version schema rules', async () => {
-    expect(result).not.toHaveLength(0);
-    expect(result).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: 'jsonapi-get-post-response-data-schema',
-          message: '"properties" property must have required property "id"',
-          path: [
-            'paths',
-            '/goof/badJsonApi/missingDataId',
-            'get',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-            'schema',
-            'properties',
-            'data',
-            'properties',
-          ],
-        }),
-        expect.objectContaining({
-          code: 'jsonapi-get-post-response-data-schema',
-          message: '"data" property must have required property "properties"',
-          path: [
-            'paths',
-            '/goof/badJsonApi/dataIdNotUuid',
-            'get',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-            'schema',
-            'properties',
-            'data',
-          ],
-        }),
-        expect.objectContaining({
-          code: 'jsonapi-get-post-response-data-schema',
-          message: '"properties.data" property must exist',
-          path: [
-            'paths',
-            '/goof/badJsonApi/dataMissingType',
-            'get',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-            'schema',
-            'properties',
-          ],
-        }),
-        expect.objectContaining({
-          code: 'jsonapi-response-jsonapi',
-          message: 'JSON:API response schema requires jsonapi property',
-          path: [
-            'paths',
-            '/goof/badJsonApi/dataMissingType',
-            'get',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-          ],
-        }),
-        expect.objectContaining({
-          code: 'jsonapi-get-post-response-data',
-          message: 'JSON:API response schema requires data property',
-          path: [
-            'paths',
-            '/goof/badJsonApi/dataMissingType',
-            'get',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-          ],
-        }),
-        expect.objectContaining({
-          code: 'jsonapi-post-response-201',
-          message:
-            'Post responses must respond with a 201 status code on success',
-          path: [
-            'paths',
-            '/goof/bad_post_status_code',
-            'post',
-            'responses',
-            '200',
-          ],
-        }),
+  describe('Schema rules', () => {
+    let result;
 
-        expect.objectContaining({
-          code: 'jsonapi-patch-response-data',
-          message: 'JSON:API patch 200 response requires a schema',
-          path: [
-            'paths',
-            '/goof/patch_missing_content',
-            'patch',
-            'responses',
-            '200',
-          ],
-        }),
+    it('fails on version schema rules', async () => {
+      // Act
+      result = await spectral.run(spec);
 
-        expect.objectContaining({
-          code: 'jsonapi-patch-response-200-schema',
-          message: 'Property "anotherField" is not expected to be here',
-          path: [
-            'paths',
-            '/goof/patch_no_meta_only',
-            'patch',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-            'schema',
-            'properties',
-          ],
-        }),
+      // Assert
+      expect(result).not.toHaveLength(0);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-get-post-response-data-schema',
+            message: '"properties" property must have required property "id"',
+            path: [
+              'paths',
+              '/goof/badJsonApi/missingDataId',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+              'schema',
+              'properties',
+              'data',
+              'properties',
+            ],
+          }),
+          expect.objectContaining({
+            code: 'jsonapi-get-post-response-data-schema',
+            message: '"data" property must have required property "properties"',
+            path: [
+              'paths',
+              '/goof/badJsonApi/dataIdNotUuid',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+              'schema',
+              'properties',
+              'data',
+            ],
+          }),
+          expect.objectContaining({
+            code: 'jsonapi-get-post-response-data-schema',
+            message: '"properties.data" property must exist',
+            path: [
+              'paths',
+              '/goof/badJsonApi/dataMissingType',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+              'schema',
+              'properties',
+            ],
+          }),
+          expect.objectContaining({
+            code: 'jsonapi-response-jsonapi',
+            message: 'JSON:API response schema requires jsonapi property',
+            path: [
+              'paths',
+              '/goof/badJsonApi/dataMissingType',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+            ],
+          }),
+          expect.objectContaining({
+            code: 'jsonapi-get-post-response-data',
+            message: 'JSON:API response schema requires data property',
+            path: [
+              'paths',
+              '/goof/badJsonApi/dataMissingType',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+            ],
+          }),
+          expect.objectContaining({
+            code: 'jsonapi-post-response-201',
+            message:
+              'Post responses must respond with a 201 status code on success',
+            path: [
+              'paths',
+              '/goof/bad_post_status_code',
+              'post',
+              'responses',
+              '200',
+            ],
+          }),
 
-        expect.objectContaining({
-          code: 'jsonapi-patch-response-200-schema',
-          message: '"properties" property must have required property "meta"',
-          path: [
-            'paths',
-            '/goof/patch_no_data',
-            'patch',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-            'schema',
-            'properties',
-          ],
-        }),
+          expect.objectContaining({
+            code: 'jsonapi-patch-response-data',
+            message: 'JSON:API patch 200 response requires a schema',
+            path: [
+              'paths',
+              '/goof/patch_missing_content',
+              'patch',
+              'responses',
+              '200',
+            ],
+          }),
+        ]),
+      );
+    });
 
-        expect.objectContaining({
-          code: 'jsonapi-patch-response-204-schema',
-          message: '"content" property must be falsy',
-          path: [
-            'paths',
-            '/goof/patch_no_content',
-            'patch',
-            'responses',
-            '204',
-            'content',
-          ],
-        }),
+    it('fails if 200 patch response contains invalid properties', async () => {
+      // Act
+      const result = await spectral.run(spec);
 
-        expect.objectContaining({
-          code: 'jsonapi-delete-response-statuses',
-          message: 'Delete endpoints can only use 200 or 204 status codes',
-          path: [
-            'paths',
-            '/goof/delete_invalid_status',
-            'delete',
-            'responses',
-            '203',
-          ],
-        }),
+      // Assert
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-patch-response-200-schema',
+            message: 'Property "anotherField" is not expected to be here',
+            path: [
+              'paths',
+              '/goof/patch_no_meta_only',
+              'patch',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+              'schema',
+              'properties',
+            ],
+          }),
+        ]),
+      );
+    });
 
-        expect.objectContaining({
-          code: 'jsonapi-delete-response-200',
-          message: '"properties" property must have required property "meta"',
-          path: [
-            'paths',
-            '/goof/delete_with_meta',
-            'delete',
-            'responses',
-            '200',
-            'content',
-            'application/vnd.api+json',
-            'schema',
-            'properties',
-          ],
-        }),
+    it('fails if 200 patch response does not have meta property', async () => {
+      // Act
+      const result = await spectral.run(spec);
 
-        expect.objectContaining({
-          code: 'jsonapi-delete-response-204',
-          message: '"content" property must be falsy',
-          path: [
-            'paths',
-            '/goof/delete_no_content',
-            'delete',
-            'responses',
-            '204',
-            'content',
-          ],
-        }),
-      ]),
-    );
+      // Assert
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-patch-response-200-schema',
+            message: '"properties" property must have required property "meta"',
+            path: [
+              'paths',
+              '/goof/patch_no_data',
+              'patch',
+              'responses',
+              '200',
+              'content',
+              'application/vnd.api+json',
+              'schema',
+              'properties',
+            ],
+          }),
+        ]),
+      );
+    });
+
+    it('fails if 204 patch response has content', async () => {
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-patch-response-204-schema',
+            message: '"content" property must be falsy',
+          }),
+        ]),
+      );
+    });
+
+    it('fails if delete response does not use 200 or 204 status code', async () => {
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-delete-response-statuses',
+            message: 'Delete endpoints can only use 200 or 204 status codes',
+          }),
+        ]),
+      );
+    });
+
+    it('fails if 200 delete response does not have meta', async () => {
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-delete-response-200',
+            message: '"properties" property must have required property "meta"',
+          }),
+        ]),
+      );
+    });
+
+    it('fails if 204 delete response has content', async () => {
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'jsonapi-delete-response-204',
+            message: '"content" property must be falsy',
+          }),
+        ]),
+      );
+    });
   });
 
   describe('Schema Rules', () => {
@@ -259,9 +293,119 @@ describe('JSON API Schema', () => {
     });
   });
 
-  describe('Collection Rules', () => {
-    let result;
+  describe('Self linking rules', () => {
+    it('fails if a GET 200 response does not have a top-level self link', async () => {
+      // Arrange
+      const spec = {
+        ...openApiDocument,
+      };
+      spec.paths = {
+        '/org/{org_id}/example': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.api+json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        data: {},
+                        jsonapi: {},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
 
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      const errorArray = getAllErrors(result, 'jsonapi-self-links-get-patch');
+      expect(errorArray).toHaveLength(1);
+    });
+
+    it('fails if a PATCH 200 response does not have a top-level self link', async () => {
+      // Arrange
+      const spec = {
+        ...openApiDocument,
+      };
+      spec.paths = {
+        '/org/{org_id}/example': {
+          patch: {
+            parameters: [],
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.api+json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        meta: {},
+                      },
+                      required: ['meta'],
+                      additionalProperties: false,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      const errorArray = getAllErrors(result, 'jsonapi-self-links-get-patch');
+      expect(errorArray).toHaveLength(1);
+    });
+
+    it('fails if a POST 201 response does not have a top-level self link', async () => {
+      // Arrange
+      const spec = {
+        ...openApiDocument,
+      };
+      spec.paths = {
+        '/org/{org_id}/example': {
+          post: {
+            parameters: [],
+            responses: {
+              201: {
+                content: {
+                  'application/vnd.api+json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        jsonapi: {},
+                        data: {},
+                      },
+                      required: ['jsonapi', 'data'],
+                      additionalProperties: false,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // Act
+      const result = await spectral.run(spec);
+
+      // Assert
+      const errorArray = getAllErrors(result, 'jsonapi-self-links-post');
+      expect(errorArray).toHaveLength(1);
+    });
+  });
+
+  describe('Collection Rules', () => {
     it('fails if collection requests do not include pagination parameters', async () => {
       // Arrange
       const spec = {
@@ -286,7 +430,7 @@ describe('JSON API Schema', () => {
       };
 
       // Act
-      result = await spectral.run(spec);
+      const result = await spectral.run(spec);
 
       // Assert
       expect(result).toEqual(
@@ -328,7 +472,7 @@ describe('JSON API Schema', () => {
       };
 
       // Act
-      result = await spectral.run(spec);
+      const result = await spectral.run(spec);
 
       // Assert
       expect(result).toEqual(
@@ -394,7 +538,7 @@ describe('JSON API Schema', () => {
       };
 
       // Act
-      result = await spectral.run(spec);
+      const result = await spectral.run(spec);
 
       // Assert
       expect(result).toEqual(
@@ -409,8 +553,6 @@ describe('JSON API Schema', () => {
   });
 
   describe('Relationships', () => {
-    let result;
-
     it('passes with correct relationship schema', async () => {
       // Arrange
       const spec = {
@@ -478,7 +620,7 @@ describe('JSON API Schema', () => {
       };
 
       // Act
-      result = await spectral.run(spec);
+      const result = await spectral.run(spec);
 
       // Assert
       const errors = getAllErrors(
@@ -547,7 +689,7 @@ describe('JSON API Schema', () => {
       };
 
       // Act
-      result = await spectral.run(spec);
+      const result = await spectral.run(spec);
 
       // Assert
       const errors = getAllErrors(
@@ -558,9 +700,3 @@ describe('JSON API Schema', () => {
     });
   });
 });
-
-function getAllErrors(errors, errorCode = '') {
-  if (!Array.isArray(errors)) return [];
-
-  return errors.filter((item) => item.code && item.code === errorCode);
-}

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -22,7 +22,14 @@ const loadSpec = (filePath) => {
   return fs.readFileSync(path.join(__dirname, filePath)).toString();
 };
 
+function getAllErrors(errors, errorCode = '') {
+  if (!Array.isArray(errors)) return [];
+
+  return errors.filter((item) => item.code && item.code === errorCode);
+}
+
 module.exports = {
   loadRules,
   loadSpec,
+  getAllErrors,
 };


### PR DESCRIPTION
For GET 200, PATCH 200 and POST 201 responses, we should attempt to ensure a top-level `self` link is present.