### PR TITLE
fix: remove redundant semantic-release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,16 +1,3 @@
 {
-  "branches": "main",
-  "verifyConditions": [
-    "@semantic-release/github"
-  ],
-  "prepare": [],
-  "publish": [
-    "@semantic-release/github"
-  ],
-  "success": [
-    "@semantic-release/github"
-  ],
-  "fail": [
-    "@semantic-release/github"
-  ]
+  "branches": "main"
 }


### PR DESCRIPTION
If I understand correctly, the config which was in place, was causing semantic release to point to github, when we want it to point to NPM. Or something.

I don’t know. There’s a lot of magic involved with this stuff.