### PR TITLE
fix: schema properties should use snake case names

### DIFF
--- a/docs/standards.md
+++ b/docs/standards.md
@@ -66,7 +66,7 @@ Entities will be commonly represented as types or classes when generating code. 
 
 ### Schema properties
 
-Schema properties use **camel case** names.
+Schema properties use **snake case** names.
 
 ### Operation IDs
 

--- a/naming.yaml
+++ b/naming.yaml
@@ -24,6 +24,16 @@ rules:
       functionOptions:
         type: snake
 
+  property-names-snake-case:
+    description: Property names must be snake_case.
+    message: '{{description}}'
+    severity: error
+    given: $..properties[*]~
+    then:
+      function: casing
+      functionOptions:
+        type: snake
+
   component-names-pascal-case:
     description: Component names must be PascalCase (except responses).
     message: '{{description}}'

--- a/tests/fixtures/propCasing.fail.yaml
+++ b/tests/fixtures/propCasing.fail.yaml
@@ -1,0 +1,158 @@
+components:
+  parameters:
+    Version:
+      description: The requested version of the endpoint to process the request
+      in: query
+      name: version
+      required: true
+      schema:
+        type: string
+    EndingBefore:
+      description: Return the page of results immediately before this cursor
+      in: query
+      name: ending_before
+      schema:
+        type: string
+    Limit:
+      description: Number of results to return per page
+      in: query
+      name: limit
+      schema:
+        default: 10
+        format: int32
+        maximum: 100
+        minimum: 10
+        multipleOf: 10
+        type: integer
+    StartingAfter:
+      description: Return the page of results immediately after this cursor
+      in: query
+      name: starting_after
+      schema:
+        type: string
+  schemas:
+    HelloWorld:
+      additionalProperties: false
+      properties:
+        attributes:
+          additionalProperties: false
+          properties:
+            deprecatedField:
+              type: string
+            message:
+              type: string
+            requestSubject:
+              additionalProperties: false
+              properties:
+                clientId:
+                  format: uuid
+                  type: string
+                publicId:
+                  format: uuid
+                  type: string
+                type:
+                  type: string
+              required:
+              - publicId
+              - type
+              type: object
+          required:
+          - message
+          - deprecatedField
+          - requestSubject
+          type: object
+        id:
+          format: uuid
+          type: string
+        type:
+          type: string
+      required:
+      - type
+      - id
+      - attributes
+      type: object
+    JsonApi:
+      additionalProperties: false
+      properties:
+        version:
+          type: string
+      required:
+      - version
+      type: object
+    LinkProperty:
+      oneOf:
+      - type: string
+      - additionalProperties: false
+        properties:
+          href:
+            type: string
+          meta:
+            additionalProperties: true
+            type: object
+        required:
+        - href
+        - meta
+        type: object
+    Links:
+      additionalProperties: false
+      properties:
+        first:
+          $ref: '#/components/schemas/LinkProperty'
+        last:
+          $ref: '#/components/schemas/LinkProperty'
+        next:
+          $ref: '#/components/schemas/LinkProperty'
+        prev:
+          $ref: '#/components/schemas/LinkProperty'
+        related:
+          $ref: '#/components/schemas/LinkProperty'
+        self:
+          $ref: '#/components/schemas/LinkProperty'
+      type: object
+    Version:
+      pattern: ^(wip|work-in-progress|experimental|beta|(([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9])))$
+      type: string
+info:
+  title: Registry
+  version: 3.0.0
+openapi: 3.0.3
+paths:
+  /examples/hello_world/{hello-id}:
+    get:
+      description: Get a single result from the hello-world example
+      operationId: helloWorldGetOne
+      parameters:
+      - $ref: '#/components/parameters/Version'
+      - $ref: '#/components/parameters/EndingBefore'
+      - $ref: '#/components/parameters/StartingAfter'
+      - $ref: '#/components/parameters/Limit'
+      - description: The hello-id of the hello-world example entity to be retrieved.
+        in: path
+        name: hello_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/vnd.api+json:
+              schema:
+                additionalProperties: false
+                properties:
+                  data:
+                    $ref: '#/components/schemas/HelloWorld'
+                  jsonapi:
+                    $ref: '#/components/schemas/JsonApi'
+                  links:
+                    $ref: '#/components/schemas/Links'
+                required:
+                - jsonapi
+                - data
+                - links
+                type: object
+          description: A hello world entity being requested is returned
+          headers: {}
+    x-snyk-api-version: "2021-06-01"
+servers:
+- description: Snyk Registry
+  url: /api/v3

--- a/tests/fixtures/valid.yaml
+++ b/tests/fixtures/valid.yaml
@@ -360,11 +360,11 @@ components:
               nullable: true
               description: The hostname for a CLI project, null if not set
               example: example.com
-            targetReference:
+            target_reference:
               type: string
               nullable: true
               example: name
-            businessCriticality:
+            business_criticality:
               type: array
               example:
                 - critical
@@ -429,7 +429,7 @@ components:
           description: The email address of the invitee.
           type: string
           example: 'example@email.com'
-        isActive:
+        is_active:
           description: The active status of the invitation.
           type: boolean
         role:
@@ -678,7 +678,7 @@ paths:
                   meta:
                     type: object
                     properties:
-                      customField:
+                      custom_field:
                         type: string
                         example: 'I have updated!'
                   links:
@@ -880,7 +880,7 @@ paths:
                   meta:
                     type: object
                     properties:
-                      customField:
+                      custom_field:
                         type: string
                         example: 'I have updated!'
                 required: [meta]

--- a/tests/propCasing.test.js
+++ b/tests/propCasing.test.js
@@ -1,0 +1,71 @@
+const { Spectral } = require('@stoplight/spectral-core');
+const { loadRules, loadSpec } = require('./utils');
+
+let rules;
+
+beforeAll(async () => {
+  rules = await loadRules('naming.yaml');
+});
+
+it('fails on snake case violation', async () => {
+  const spectral = new Spectral();
+  spectral.setRuleset(rules);
+  const result = await spectral.run(loadSpec('fixtures/propCasing.fail.yaml'));
+  expect(result).toHaveLength(8);
+  expect(result).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        code: 'property-names-snake-case',
+        path: [
+          'components',
+          'schemas',
+          'HelloWorld',
+          'properties',
+          'attributes',
+          'properties',
+          'deprecatedField',
+        ],
+      }),
+      expect.objectContaining({
+        code: 'property-names-snake-case',
+        path: [
+          'components',
+          'schemas',
+          'HelloWorld',
+          'properties',
+          'attributes',
+          'properties',
+          'requestSubject',
+        ],
+      }),
+      expect.objectContaining({
+        code: 'property-names-snake-case',
+        path: [
+          'components',
+          'schemas',
+          'HelloWorld',
+          'properties',
+          'attributes',
+          'properties',
+          'requestSubject',
+          'properties',
+          'clientId',
+        ],
+      }),
+      expect.objectContaining({
+        code: 'property-names-snake-case',
+        path: [
+          'components',
+          'schemas',
+          'HelloWorld',
+          'properties',
+          'attributes',
+          'properties',
+          'requestSubject',
+          'properties',
+          'publicId',
+        ],
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
Per discussion today w/ @ianlivingstone, we want property names to be
consistent with parameter names, which means snake_case.