### PR TITLE
chore: add compare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "jest --colors",
     "build": "yarn tsc --build --verbose",
-    "clean": "rm -rf build"
+    "clean": "rm -rf build",
+    "compare": "yarn ts-node src/index.ts compare"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.16.0",


### PR DESCRIPTION
This allows running Optic from yarn:

`yarn run compare --from fromfile.yaml --to tofile.yaml`