### PR TITLE
Add lifecycle rules for parameters and responses 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "ts-node": "^10.4.0"
   },
   "dependencies": {
-    "@useoptic/api-checks": "0.3.3",
-    "@useoptic/openapi-utilities": "0.3.3",
+    "@useoptic/api-checks": "0.4.0",
+    "@useoptic/openapi-utilities": "0.4.0",
     "fs-extra": "^10.0.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "ts-node": "^10.4.0"
   },
   "dependencies": {
-    "@useoptic/api-checks": "0.3.2",
-    "@useoptic/openapi-utilities": "0.3.2",
+    "@useoptic/api-checks": "0.3.3",
+    "@useoptic/openapi-utilities": "0.3.3",
     "fs-extra": "^10.0.0"
   },
   "jest": {

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -5,7 +5,11 @@ import {
   DocsLinkHelper,
   newDocsLinkHelper,
   runCheck,
+  createSelectJsonPathHelper,
 } from "@useoptic/api-checks";
+
+import niceTry from "nice-try";
+
 import {
   ConceptualLocation,
   OpenApiHeaderFact,
@@ -20,7 +24,10 @@ import {
 } from "@useoptic/openapi-utilities";
 import { genericEntityRuleImpl } from "@useoptic/api-checks/build/sdk/generic-entity-rule-impl";
 import { ShouldOrMust } from "@useoptic/api-checks/build/sdk/types";
-import { OpenApiResponseFact } from "@useoptic/openapi-utilities/build/openapi3/implementations/openapi3/openapi-traverser";
+import {
+  OpenApiRequestParameterFact,
+  OpenApiResponseFact,
+} from "@useoptic/openapi-utilities/build/openapi3/implementations/openapi3/openapi-traverser";
 
 type SnykStablity = "wip" | "experimental" | "beta" | "ga";
 type DateString = string; // YYYY-mm-dd
@@ -69,6 +76,7 @@ export class SnykApiCheckDsl implements ApiCheckDsl {
   constructor(
     private nextFacts: IFact<any>[],
     private changelog: IChange<any>[],
+    private currentJsonLike: OpenAPIV3.Document,
     private nextJsonLike: OpenAPIV3.Document,
     private providedContext: SynkApiCheckContext
   ) {}
@@ -85,20 +93,58 @@ export class SnykApiCheckDsl implements ApiCheckDsl {
   }
 
   get operations() {
-    return genericEntityRuleImpl<
-      OpenApiOperationFact,
-      ConceptualLocation,
-      SynkApiCheckContext,
-      OpenAPIV3.OperationObject
-    >(
-      OpenApiKind.Operation,
-      this.changelog,
-      this.nextFacts,
-      (opFact) => `${opFact.method.toUpperCase()} ${opFact.pathPattern}`,
-      (location) => this.getContext(location),
-      (...items) => this.checks.push(...items),
-      (pointer: string) => jsonPointerHelper.get(this.nextJsonLike, pointer)
+    const operations = this.changelog.filter(
+      (i) => i.location.kind === OpenApiKind.Operation
     );
+
+    const added = operations.filter((i) =>
+      Boolean(i.added)
+    ) as IChange<OpenApiOperationFact>[];
+    const removed = operations.filter((i) =>
+      Boolean(i.removed)
+    ) as IChange<OpenApiOperationFact>[];
+    const changes = operations.filter((i) =>
+      Boolean(i.changed)
+    ) as IChange<OpenApiOperationFact>[];
+
+    const locations = [
+      ...added.map((i) => i.location),
+      ...changes.map((i) => i.location),
+      ...removed.map((i) => i.location),
+    ];
+
+    const pathsSelectorsInputs = locations.map((i) => {
+      return {
+        conceptualLocation: i.conceptualLocation,
+        current:
+          niceTry(() =>
+            jsonPointerHelper.get(this.currentJsonLike, i.jsonPath)
+          ) || {},
+        next:
+          niceTry(() => jsonPointerHelper.get(this.nextJsonLike, i.jsonPath)) ||
+          {},
+      };
+    });
+
+    const { selectJsonPath } = createSelectJsonPathHelper(pathsSelectorsInputs);
+
+    return {
+      selectJsonPath,
+      ...genericEntityRuleImpl<
+        OpenApiOperationFact,
+        ConceptualLocation,
+        SynkApiCheckContext,
+        OpenAPIV3.OperationObject
+      >(
+        OpenApiKind.Operation,
+        this.changelog,
+        this.nextFacts,
+        (opFact) => `${opFact.method.toUpperCase()} ${opFact.pathPattern}`,
+        (location) => this.getContext(location),
+        (...items) => this.checks.push(...items),
+        (pointer: string) => jsonPointerHelper.get(this.nextJsonLike, pointer)
+      ),
+    };
   }
 
   get context() {
@@ -142,6 +188,55 @@ export class SnykApiCheckDsl implements ApiCheckDsl {
     };
 
     return value;
+  }
+
+  get request() {
+    const dsl = this;
+
+    return {
+      queryParameter: genericEntityRuleImpl<
+        OpenApiRequestParameterFact,
+        ConceptualLocation,
+        SynkApiCheckContext,
+        OpenAPIV3.ParameterObject
+      >(
+        OpenApiKind.QueryParameter,
+        dsl.changelog,
+        dsl.nextFacts,
+        (query) => `query parameter ${query.name}`,
+        (location) => dsl.getContext(location),
+        (...items) => dsl.checks.push(...items),
+        (pointer: string) => jsonPointerHelper.get(dsl.nextJsonLike, pointer)
+      ),
+      pathParameter: genericEntityRuleImpl<
+        OpenApiRequestParameterFact,
+        ConceptualLocation,
+        SynkApiCheckContext,
+        OpenAPIV3.ParameterObject
+      >(
+        OpenApiKind.PathParameter,
+        dsl.changelog,
+        dsl.nextFacts,
+        (path) => `path parameter ${path.name}`,
+        (location) => dsl.getContext(location),
+        (...items) => dsl.checks.push(...items),
+        (pointer: string) => jsonPointerHelper.get(dsl.nextJsonLike, pointer)
+      ),
+      header: genericEntityRuleImpl<
+        OpenApiRequestParameterFact,
+        ConceptualLocation,
+        SynkApiCheckContext,
+        OpenAPIV3.ParameterObject
+      >(
+        OpenApiKind.HeaderParameter,
+        dsl.changelog,
+        dsl.nextFacts,
+        (header) => `header parameter ${header.name}`,
+        (location) => dsl.getContext(location),
+        (...items) => dsl.checks.push(...items),
+        (pointer: string) => jsonPointerHelper.get(dsl.nextJsonLike, pointer)
+      ),
+    };
   }
 
   get responses() {

--- a/src/rulesets/operations.ts
+++ b/src/rulesets/operations.ts
@@ -65,4 +65,38 @@ export const rules = {
       }
     );
   },
+  preventAddingRequiredQueryParameters: ({ request }: SnykApiCheckDsl) => {
+    request.queryParameter.added.must("not be required", (queryParameter) => {
+      expect(queryParameter.required).to.not.be.true;
+    });
+  },
+  preventChangingOptionalToRequiredQueryParameters: ({
+    request,
+  }: SnykApiCheckDsl) => {
+    request.queryParameter.changed.must(
+      "not be optional then required",
+      (queryParameterBefore, queryParameterAfter) => {
+        if (!queryParameterBefore.required) {
+          expect(queryParameterAfter.required).to.not.be.true;
+        }
+      }
+    );
+  },
+  preventRemovingStatusCodes: ({ responses }: SnykApiCheckDsl) => {
+    responses.removed.must("not be removed", (response) => {
+      expect(false, `expected ${response.statusCode} to be present`).to.be.true;
+    });
+  },
+  preventChangingParameterDefaultValue: ({ request }: SnykApiCheckDsl) => {
+    request.queryParameter.changed.must(
+      "not change the default value",
+      (parameterBefore, parameterAfter) => {
+        let beforeSchema = parameterBefore.schema || {};
+        let afterSchema = parameterAfter.schema || {};
+        if ("default" in beforeSchema && "default" in afterSchema) {
+          expect(beforeSchema.default).to.equal(afterSchema.default);
+        }
+      }
+    );
+  },
 };

--- a/src/rulesets/properties.ts
+++ b/src/rulesets/properties.ts
@@ -1,25 +1,38 @@
-import { SnykApiCheckDsl } from '../dsl';
-const { expect } = require('chai');
+import { SnykApiCheckDsl } from "../dsl";
+const { expect } = require("chai");
 export const rules = {
   propertyKey: ({ bodyProperties }: SnykApiCheckDsl) => {
-    bodyProperties.requirement.must('have camel case keys', ({ key }) => {
-      const camelCaseRe = /^[a-z]+([A-Z][a-z]+)+$/g;
-      expect(camelCaseRe.test(key)).to.be.ok;
+    bodyProperties.requirement.must("have camel case keys", ({ key }) => {
+      const snakeCase = /^[a-z]+(?:_[a-z]+)*$/g;
+      expect(snakeCase.test(key)).to.be.ok;
     });
   },
   propertyExample: ({ bodyProperties }: SnykApiCheckDsl) => {
-    bodyProperties.requirement.must('have an example', ({ flatSchema }) => {
+    bodyProperties.requirement.must("have an example", ({ flatSchema }) => {
       expect(flatSchema.example).to.exist;
     });
   },
   propertyFormat: ({ bodyProperties }: SnykApiCheckDsl) => {
     bodyProperties.requirement.should(
-      'have a format when a string',
+      "have a format when a string",
       ({ flatSchema }) => {
-        if (flatSchema.type === 'string') {
+        if (flatSchema.type === "string") {
           expect(flatSchema.format).to.exist;
         }
-      },
+      }
     );
+  },
+  preventRemoval: ({ bodyProperties }: SnykApiCheckDsl) => {
+    bodyProperties.removed.must("not be removed", (property) => {
+      expect(false, `expected ${property.key} to be present`).to.be.ok;
+    });
+  },
+  preventAddingRequiredRequestProperties: ({
+    bodyProperties,
+  }: SnykApiCheckDsl) => {
+    bodyProperties.added.must("not be required", (property, context) => {
+      if (!context.inRequest) return;
+      expect(property.required).to.not.be.true;
+    });
   },
 };

--- a/src/rulesets/tests/__snapshots__/operations.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/operations.test.ts.snap
@@ -473,7 +473,7 @@ Object {
           "pathParameter",
         ],
         "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/0",
-        "kind": "path",
+        "kind": "path-parameter",
       },
     },
     Object {
@@ -571,6 +571,408 @@ Object {
 }
 `;
 
+exports[`operation parameters names fails if the default value is changed 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "parameters": Array [
+            Object {
+              "in": "query",
+              "name": "query_parameter",
+              "schema": Object {
+                "default": "before",
+                "type": "string",
+              },
+            },
+          ],
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "changelog": Array [
+    Object {
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "after",
+            "type": "string",
+          },
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "before",
+            "type": "string",
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "parameters": Array [
+            Object {
+              "in": "query",
+              "name": "query_parameter",
+              "schema": Object {
+                "default": "after",
+                "type": "string",
+              },
+            },
+          ],
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "changed": Object {
+          "after": Object {
+            "in": "query",
+            "name": "query_parameter",
+            "schema": Object {
+              "default": "after",
+              "type": "string",
+            },
+          },
+          "before": Object {
+            "in": "query",
+            "name": "query_parameter",
+            "schema": Object {
+              "default": "before",
+              "type": "string",
+            },
+          },
+        },
+        "location": Object {
+          "conceptualLocation": Object {
+            "inRequest": Object {
+              "query": "query_parameter",
+            },
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+            "parameters",
+            "query",
+            "query_parameter",
+          ],
+          "jsonPath": "/paths/~1example/get/parameters/0",
+          "kind": "query-parameter",
+        },
+      },
+      "condition": "not change the default value",
+      "docsLink": undefined,
+      "error": "expected 'before' to equal 'after'",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "updated query-parameter: query parameter query_parameter",
+    },
+  ],
+}
+`;
+
+exports[`operation parameters names fails when adding a required query parameter 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "changelog": Array [
+    Object {
+      "added": Object {
+        "in": "query",
+        "name": "query_parameter",
+        "required": true,
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "parameters": Array [
+            Object {
+              "in": "query",
+              "name": "query_parameter",
+              "required": true,
+            },
+          ],
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "added": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "required": true,
+        },
+        "location": Object {
+          "conceptualLocation": Object {
+            "inRequest": Object {
+              "query": "query_parameter",
+            },
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+            "parameters",
+            "query",
+            "query_parameter",
+          ],
+          "jsonPath": "/paths/~1example/get/parameters/0",
+          "kind": "query-parameter",
+        },
+      },
+      "condition": "not be required",
+      "docsLink": undefined,
+      "error": "expected true to be false",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "added query-parameter: query parameter query_parameter",
+    },
+  ],
+}
+`;
+
+exports[`operation parameters names fails when changing optional to required query parameter 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "parameters": Array [
+            Object {
+              "in": "query",
+              "name": "query_parameter",
+            },
+          ],
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "changelog": Array [
+    Object {
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "required": true,
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "parameters": Array [
+            Object {
+              "in": "query",
+              "name": "query_parameter",
+              "required": true,
+            },
+          ],
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "changed": Object {
+          "after": Object {
+            "in": "query",
+            "name": "query_parameter",
+            "required": true,
+          },
+          "before": Object {
+            "in": "query",
+            "name": "query_parameter",
+          },
+        },
+        "location": Object {
+          "conceptualLocation": Object {
+            "inRequest": Object {
+              "query": "query_parameter",
+            },
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+            "parameters",
+            "query",
+            "query_parameter",
+          ],
+          "jsonPath": "/paths/~1example/get/parameters/0",
+          "kind": "query-parameter",
+        },
+      },
+      "condition": "not be optional then required",
+      "docsLink": undefined,
+      "error": "expected true to be false",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "updated query-parameter: query parameter query_parameter",
+    },
+  ],
+}
+`;
+
 exports[`operation parameters names passes if the case is correct 1`] = `
 Object {
   "base": Object {
@@ -634,7 +1036,7 @@ Object {
           "path_parameter",
         ],
         "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/0",
-        "kind": "path",
+        "kind": "path-parameter",
       },
     },
     Object {
@@ -726,6 +1128,158 @@ Object {
       "isShould": false,
       "passed": true,
       "where": "requirement for operation: GET /example/{path_parameter}",
+    },
+  ],
+}
+`;
+
+exports[`operation parameters status codes fails when a status codes is removed 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "responses": Object {
+            "200": Object {
+              "description": "Example response",
+            },
+          },
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "changelog": Array [
+    Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200",
+        "kind": "response",
+      },
+      "removed": Object {
+        "before": Object {
+          "location": Object {
+            "conceptualLocation": Object {
+              "inResponse": Object {
+                "statusCode": "200",
+              },
+              "method": "get",
+              "path": "/example",
+            },
+            "conceptualPath": Array [
+              "operations",
+              "/example",
+              "get",
+              "responses",
+              "200",
+            ],
+            "jsonPath": "/paths/~1example/get/responses/200",
+            "kind": "response",
+          },
+          "value": Object {
+            "description": "Example response",
+            "statusCode": 200,
+          },
+        },
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "operationId": "getExample",
+          "responses": Object {},
+          "summary": "Retrieve example",
+          "tags": Array [
+            "Example",
+          ],
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "location": Object {
+          "conceptualLocation": Object {
+            "inResponse": Object {
+              "statusCode": "200",
+            },
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+            "responses",
+            "200",
+          ],
+          "jsonPath": "/paths/~1example/get/responses/200",
+          "kind": "response",
+        },
+        "removed": Object {
+          "before": Object {
+            "location": Object {
+              "conceptualLocation": Object {
+                "inResponse": Object {
+                  "statusCode": "200",
+                },
+                "method": "get",
+                "path": "/example",
+              },
+              "conceptualPath": Array [
+                "operations",
+                "/example",
+                "get",
+                "responses",
+                "200",
+              ],
+              "jsonPath": "/paths/~1example/get/responses/200",
+              "kind": "response",
+            },
+            "value": Object {
+              "description": "Example response",
+              "statusCode": 200,
+            },
+          },
+        },
+      },
+      "condition": "not be removed",
+      "docsLink": undefined,
+      "error": "Cannot read property 'statusCode' of undefined",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "removed response: response undefined",
     },
   ],
 }
@@ -854,7 +1408,7 @@ Object {
           "version",
         ],
         "jsonPath": "/paths/~1example/get/parameters/0",
-        "kind": "query",
+        "kind": "query-parameter",
       },
     },
   ],

--- a/src/rulesets/tests/__snapshots__/properties.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/properties.test.ts.snap
@@ -1,5 +1,398 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`body properties breaking changes fails if a property is removed 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "application/json": Object {
+                  "schema": Object {
+                    "properties": Object {
+                      "count": Object {
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+              },
+              "description": "",
+            },
+          },
+        },
+      },
+    },
+  },
+  "changelog": Array [
+    Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "count",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "count",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/count",
+        "kind": "field",
+      },
+      "removed": Object {
+        "before": Object {
+          "location": Object {
+            "conceptualLocation": Object {
+              "inResponse": Object {
+                "body": Object {
+                  "contentType": "application/json",
+                },
+                "statusCode": "200",
+              },
+              "jsonSchemaTrail": Array [
+                "count",
+              ],
+              "method": "get",
+              "path": "/example",
+            },
+            "conceptualPath": Array [
+              "operations",
+              "/example",
+              "get",
+              "responses",
+              "200",
+              "application/json",
+              "count",
+            ],
+            "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/count",
+            "kind": "field",
+          },
+          "value": Object {
+            "flatSchema": Object {
+              "type": "number",
+            },
+            "key": "count",
+            "required": false,
+          },
+        },
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "application/json": Object {
+                  "schema": Object {
+                    "properties": Object {},
+                    "type": "object",
+                  },
+                },
+              },
+              "description": "",
+            },
+          },
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "location": Object {
+          "conceptualLocation": Object {
+            "inResponse": Object {
+              "body": Object {
+                "contentType": "application/json",
+              },
+              "statusCode": "200",
+            },
+            "jsonSchemaTrail": Array [
+              "count",
+            ],
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+            "responses",
+            "200",
+            "application/json",
+            "count",
+          ],
+          "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/count",
+          "kind": "field",
+        },
+        "removed": Object {
+          "before": Object {
+            "location": Object {
+              "conceptualLocation": Object {
+                "inResponse": Object {
+                  "body": Object {
+                    "contentType": "application/json",
+                  },
+                  "statusCode": "200",
+                },
+                "jsonSchemaTrail": Array [
+                  "count",
+                ],
+                "method": "get",
+                "path": "/example",
+              },
+              "conceptualPath": Array [
+                "operations",
+                "/example",
+                "get",
+                "responses",
+                "200",
+                "application/json",
+                "count",
+              ],
+              "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/count",
+              "kind": "field",
+            },
+            "value": Object {
+              "flatSchema": Object {
+                "type": "number",
+              },
+              "key": "count",
+              "required": false,
+            },
+          },
+        },
+      },
+      "condition": "not be removed",
+      "docsLink": undefined,
+      "error": "Cannot read property 'key' of undefined",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "removed field: field undefined",
+    },
+  ],
+}
+`;
+
+exports[`body properties breaking changes fails if a required property is added 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {},
+                  "type": "object",
+                },
+              },
+            },
+          },
+          "responses": Object {},
+        },
+      },
+    },
+  },
+  "changelog": Array [
+    Object {
+      "added": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "count",
+        "required": true,
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "count",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "application/json",
+          "count",
+        ],
+        "jsonPath": "/paths/~1example/get/requestBody/content/application~1json/schema/properties/count",
+        "kind": "field",
+      },
+    },
+    Object {
+      "changed": Object {
+        "after": Object {
+          "method": "get",
+          "pathPattern": "/example",
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "count": Object {
+                      "type": "number",
+                    },
+                  },
+                  "required": Array [
+                    "count",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+        "before": Object {
+          "method": "get",
+          "pathPattern": "/example",
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {},
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "Empty",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/example": Object {
+        "get": Object {
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "count": Object {
+                      "type": "number",
+                    },
+                  },
+                  "required": Array [
+                    "count",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+          },
+          "responses": Object {},
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "added": Object {
+          "flatSchema": Object {
+            "type": "number",
+          },
+          "key": "count",
+          "required": true,
+        },
+        "location": Object {
+          "conceptualLocation": Object {
+            "inRequest": Object {
+              "body": Object {
+                "contentType": "application/json",
+              },
+            },
+            "jsonSchemaTrail": Array [
+              "count",
+            ],
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+            "application/json",
+            "count",
+          ],
+          "jsonPath": "/paths/~1example/get/requestBody/content/application~1json/schema/properties/count",
+          "kind": "field",
+        },
+      },
+      "condition": "not be required",
+      "docsLink": undefined,
+      "error": "expected true to be false",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "added field: field count",
+    },
+  ],
+}
+`;
+
 exports[`body properties example fails if doesn't exist 1`] = `
 Object {
   "base": Object {
@@ -745,7 +1138,7 @@ Object {
 }
 `;
 
-exports[`body properties key fails when not camel case 1`] = `
+exports[`body properties key fails when not snake case 1`] = `
 Object {
   "base": Object {
     "info": Object {
@@ -797,7 +1190,7 @@ Object {
         "flatSchema": Object {
           "type": "string",
         },
-        "key": "not-camel-case",
+        "key": "not-snake-case",
         "required": false,
       },
       "location": Object {
@@ -809,7 +1202,7 @@ Object {
             "statusCode": "200",
           },
           "jsonSchemaTrail": Array [
-            "not-camel-case",
+            "not-snake-case",
           ],
           "method": "get",
           "path": "/example",
@@ -821,9 +1214,9 @@ Object {
           "responses",
           "200",
           "application/json",
-          "not-camel-case",
+          "not-snake-case",
         ],
-        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/not-camel-case",
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/not-snake-case",
         "kind": "field",
       },
     },
@@ -867,7 +1260,7 @@ Object {
                 "application/json": Object {
                   "schema": Object {
                     "properties": Object {
-                      "not-camel-case": Object {
+                      "not-snake-case": Object {
                         "type": "string",
                       },
                     },
@@ -894,7 +1287,7 @@ Object {
               "statusCode": "200",
             },
             "jsonSchemaTrail": Array [
-              "not-camel-case",
+              "not-snake-case",
             ],
             "method": "get",
             "path": "/example",
@@ -906,16 +1299,16 @@ Object {
             "responses",
             "200",
             "application/json",
-            "not-camel-case",
+            "not-snake-case",
           ],
-          "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/not-camel-case",
+          "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/not-snake-case",
           "kind": "field",
         },
         "value": Object {
           "flatSchema": Object {
             "type": "string",
           },
-          "key": "not-camel-case",
+          "key": "not-snake-case",
           "required": false,
         },
       },
@@ -925,13 +1318,13 @@ Object {
       "isMust": true,
       "isShould": false,
       "passed": false,
-      "where": "requirement for field: field not-camel-case",
+      "where": "requirement for field: field not-snake-case",
     },
   ],
 }
 `;
 
-exports[`body properties key passes when camel case 1`] = `
+exports[`body properties key passes when snake case 1`] = `
 Object {
   "base": Object {
     "info": Object {
@@ -983,7 +1376,7 @@ Object {
         "flatSchema": Object {
           "type": "string",
         },
-        "key": "isCamelCase",
+        "key": "is_snake_case",
         "required": false,
       },
       "location": Object {
@@ -995,7 +1388,7 @@ Object {
             "statusCode": "200",
           },
           "jsonSchemaTrail": Array [
-            "isCamelCase",
+            "is_snake_case",
           ],
           "method": "get",
           "path": "/example",
@@ -1007,9 +1400,9 @@ Object {
           "responses",
           "200",
           "application/json",
-          "isCamelCase",
+          "is_snake_case",
         ],
-        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/isCamelCase",
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/is_snake_case",
         "kind": "field",
       },
     },
@@ -1053,7 +1446,7 @@ Object {
                 "application/json": Object {
                   "schema": Object {
                     "properties": Object {
-                      "isCamelCase": Object {
+                      "is_snake_case": Object {
                         "type": "string",
                       },
                     },
@@ -1080,7 +1473,7 @@ Object {
               "statusCode": "200",
             },
             "jsonSchemaTrail": Array [
-              "isCamelCase",
+              "is_snake_case",
             ],
             "method": "get",
             "path": "/example",
@@ -1092,16 +1485,16 @@ Object {
             "responses",
             "200",
             "application/json",
-            "isCamelCase",
+            "is_snake_case",
           ],
-          "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/isCamelCase",
+          "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/is_snake_case",
           "kind": "field",
         },
         "value": Object {
           "flatSchema": Object {
             "type": "string",
           },
-          "key": "isCamelCase",
+          "key": "is_snake_case",
           "required": false,
         },
       },
@@ -1110,7 +1503,7 @@ Object {
       "isMust": true,
       "isShould": false,
       "passed": true,
-      "where": "requirement for field: field isCamelCase",
+      "where": "requirement for field: field is_snake_case",
     },
   ],
 }

--- a/src/rulesets/tests/fixtures.ts
+++ b/src/rulesets/tests/fixtures.ts
@@ -1,5 +1,5 @@
 import { SnykApiCheckDsl, SynkApiCheckContext } from "../../dsl";
-import { ApiCheckService } from "@useoptic/api-checks";
+import { ApiCheckService, createTestDslFixture } from "@useoptic/api-checks";
 import { OpenAPIV3 } from "@useoptic/openapi-utilities";
 import path from "path";
 export async function rulesFixture(
@@ -13,6 +13,7 @@ export async function rulesFixture(
     return new SnykApiCheckDsl(
       input.nextFacts,
       input.changelog,
+      input.currentJsonLike,
       input.nextJsonLike,
       input.context
     );
@@ -24,4 +25,16 @@ export async function rulesFixture(
 export async function inputFrom(dir: string, name: string) {
   const inputs = path.join(__dirname, "inputs", dir, name);
   return path.resolve(inputs);
+}
+
+export function createSnykTestFixture() {
+  return createTestDslFixture<SnykApiCheckDsl, SynkApiCheckContext>((input) => {
+    return new SnykApiCheckDsl(
+      input.nextFacts,
+      input.changelog,
+      input.currentJsonLike,
+      input.nextJsonLike,
+      input.context
+    );
+  });
 }

--- a/src/rulesets/tests/headers.test.ts
+++ b/src/rulesets/tests/headers.test.ts
@@ -1,20 +1,9 @@
 import { rules } from "../headers";
-import { createTestDslFixture } from "@useoptic/api-checks";
 import { SnykApiCheckDsl, SynkApiCheckContext } from "../../dsl";
+import { createSnykTestFixture } from "./fixtures";
 
-// todo: fix copy/paste
-const { compare } = createTestDslFixture<SnykApiCheckDsl, SynkApiCheckContext>(
-  (input) => {
-    return new SnykApiCheckDsl(
-      input.nextFacts,
-      input.changelog,
-      input.nextJsonLike,
-      input.context
-    );
-  }
-);
+const { compare } = createSnykTestFixture();
 
-// todo: fix copy/paste
 const emptyContext: SynkApiCheckContext = {
   changeDate: "2021-10-10",
   changeResource: "Example",

--- a/src/rulesets/tests/operations.test.ts
+++ b/src/rulesets/tests/operations.test.ts
@@ -1,37 +1,37 @@
-import { rules } from "../operations";
-import { SnykApiCheckDsl, SynkApiCheckContext } from "../../dsl";
+import { rules } from '../operations';
+import { SnykApiCheckDsl, SynkApiCheckContext } from '../../dsl';
 
-import { createSnykTestFixture } from "./fixtures";
+import { createSnykTestFixture } from './fixtures';
 const { compare } = createSnykTestFixture();
 
 const emptyContext: SynkApiCheckContext = {
-  changeDate: "2021-10-10",
-  changeResource: "Example",
+  changeDate: '2021-10-10',
+  changeResource: 'Example',
   changeVersion: {
-    date: "2021-10-10",
-    stability: "ga",
+    date: '2021-10-10',
+    stability: 'ga',
   },
   resourceVersions: {},
 };
 
-describe("operationId", () => {
+describe('operationId', () => {
   const baseForOperationIdTests = {
-    openapi: "3.0.1",
+    openapi: '3.0.1',
     paths: {
-      "/example": {
+      '/example': {
         get: {
           responses: {},
         },
       },
     },
-    info: { version: "0.0.0", title: "Empty" },
+    info: { version: '0.0.0', title: 'Empty' },
   };
 
-  describe("missing", () => {
-    it("fails if empty string", async () => {
+  describe('missing', () => {
+    it('fails if empty string', async () => {
       const result = await compare(baseForOperationIdTests)
         .to((spec) => {
-          spec.paths!["/example"]!.get!.operationId = "";
+          spec.paths!['/example']!.get!.operationId = '';
           return spec;
         })
         .withRule(rules.operationId, emptyContext);
@@ -40,36 +40,10 @@ describe("operationId", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("fails if undefined", async () => {
+    it('fails if undefined', async () => {
       const result = await compare(baseForOperationIdTests)
         .to((spec) => {
-          delete spec.paths!["/example"]!.get!.operationId;
-          return spec;
-        })
-        .withRule(rules.operationId, emptyContext);
-
-      expect(result.results[0].passed).toBeFalsy();
-      expect(result).toMatchSnapshot();
-    });
-  });
-
-  describe("when set", () => {
-    it("fails if prefix is wrong", async () => {
-      const result = await compare(baseForOperationIdTests)
-        .to((spec) => {
-          spec.paths!["/example"]!.get!.operationId = "findHelloWorld";
-          return spec;
-        })
-        .withRule(rules.operationId, emptyContext);
-
-      expect(result.results[0].passed).toBeFalsy();
-      expect(result).toMatchSnapshot();
-    });
-
-    it("fails if not camel case", async () => {
-      const result = await compare(baseForOperationIdTests)
-        .to((spec) => {
-          spec.paths!["/example"]!.get!.operationId = "get-hello-world";
+          delete spec.paths!['/example']!.get!.operationId;
           return spec;
         })
         .withRule(rules.operationId, emptyContext);
@@ -79,12 +53,38 @@ describe("operationId", () => {
     });
   });
 
-  it("fails if removed", async () => {
+  describe('when set', () => {
+    it('fails if prefix is wrong', async () => {
+      const result = await compare(baseForOperationIdTests)
+        .to((spec) => {
+          spec.paths!['/example']!.get!.operationId = 'findHelloWorld';
+          return spec;
+        })
+        .withRule(rules.operationId, emptyContext);
+
+      expect(result.results[0].passed).toBeFalsy();
+      expect(result).toMatchSnapshot();
+    });
+
+    it('fails if not camel case', async () => {
+      const result = await compare(baseForOperationIdTests)
+        .to((spec) => {
+          spec.paths!['/example']!.get!.operationId = 'get-hello-world';
+          return spec;
+        })
+        .withRule(rules.operationId, emptyContext);
+
+      expect(result.results[0].passed).toBeFalsy();
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  it('fails if removed', async () => {
     const baseCopy = JSON.parse(JSON.stringify(baseForOperationIdTests));
-    baseCopy.paths["/example"].get.operationId = "example";
+    baseCopy.paths['/example'].get.operationId = 'example';
     const result = await compare(baseCopy)
       .to((spec) => {
-        delete spec.paths!["/example"]!.get!.operationId;
+        delete spec.paths!['/example']!.get!.operationId;
         return spec;
       })
       .withRule(rules.removingOperationId, emptyContext);
@@ -93,13 +93,13 @@ describe("operationId", () => {
     expect(result).toMatchSnapshot();
   });
 
-  it("fails if changed", async () => {
+  it('fails if changed', async () => {
     // todo: fix copy/paste
     const baseCopy = JSON.parse(JSON.stringify(baseForOperationIdTests));
-    baseCopy.paths["/example"].get.operationId = "example";
+    baseCopy.paths['/example'].get.operationId = 'example';
     const result = await compare(baseCopy)
       .to((spec) => {
-        spec.paths!["/example"]!.get!.operationId = "example2";
+        spec.paths!['/example']!.get!.operationId = 'example2';
         return spec;
       })
       .withRule(rules.removingOperationId, emptyContext);
@@ -110,26 +110,26 @@ describe("operationId", () => {
 });
 
 const baseForOperationMetadataTests = {
-  openapi: "3.0.1",
+  openapi: '3.0.1',
   paths: {
-    "/example": {
+    '/example': {
       get: {
-        tags: ["Example"],
-        operationId: "getExample",
-        summary: "Retrieve example",
+        tags: ['Example'],
+        operationId: 'getExample',
+        summary: 'Retrieve example',
         responses: {},
       },
     },
   },
-  info: { version: "0.0.0", title: "Empty" },
+  info: { version: '0.0.0', title: 'Empty' },
 };
 
-describe("operation metadata", () => {
-  describe("summary", () => {
-    it("fails if missing", async () => {
+describe('operation metadata', () => {
+  describe('summary', () => {
+    it('fails if missing', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          delete spec.paths!["/example"]!.get!.summary;
+          delete spec.paths!['/example']!.get!.summary;
           return spec;
         })
         .withRule(rules.summary, emptyContext);
@@ -138,10 +138,10 @@ describe("operation metadata", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("passes if provided", async () => {
+    it('passes if provided', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          spec.paths!["/example"]!.get!.summary = "I have a summary";
+          spec.paths!['/example']!.get!.summary = 'I have a summary';
           return spec;
         })
         .withRule(rules.summary, emptyContext);
@@ -151,8 +151,8 @@ describe("operation metadata", () => {
     });
   });
 
-  describe("tags", () => {
-    it("passes if > 1 tag provided", async () => {
+  describe('tags', () => {
+    it('passes if > 1 tag provided', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => spec)
         .withRule(rules.tags, emptyContext);
@@ -161,10 +161,10 @@ describe("operation metadata", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("fail is not provided", async () => {
+    it('fail is not provided', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          delete spec.paths!["/example"]!.get!.tags;
+          delete spec.paths!['/example']!.get!.tags;
           return spec;
         })
         .withRule(rules.tags, emptyContext);
@@ -175,18 +175,18 @@ describe("operation metadata", () => {
   });
 });
 
-describe("operation parameters", () => {
-  describe("names", () => {
+describe('operation parameters', () => {
+  describe('names', () => {
     it("fails if the case isn't correct", async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          delete spec.paths!["/example"];
-          spec.paths!["/example/{pathParameter}"] = {
+          delete spec.paths!['/example'];
+          spec.paths!['/example/{pathParameter}'] = {
             get: {
               parameters: [
                 {
-                  in: "path",
-                  name: "pathParameter",
+                  in: 'path',
+                  name: 'pathParameter',
                 },
               ],
               responses: {},
@@ -200,16 +200,16 @@ describe("operation parameters", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("passes if the case is correct", async () => {
+    it('passes if the case is correct', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          delete spec.paths!["/example"];
-          spec.paths!["/example/{path_parameter}"] = {
+          delete spec.paths!['/example'];
+          spec.paths!['/example/{path_parameter}'] = {
             get: {
               parameters: [
                 {
-                  in: "path",
-                  name: "path_parameter",
+                  in: 'path',
+                  name: 'path_parameter',
                 },
               ],
               responses: {},
@@ -223,15 +223,13 @@ describe("operation parameters", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("fails when adding a required query parameter", async () => {
-      // const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
-      // base.paths!["/example"]!.get!.parameters = [];
+    it('fails when adding a required query parameter', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          spec.paths!["/example"]!.get!.parameters = [
+          spec.paths!['/example']!.get!.parameters = [
             {
-              in: "query",
-              name: "query_parameter",
+              in: 'query',
+              name: 'query_parameter',
               required: true,
             },
           ];
@@ -243,20 +241,20 @@ describe("operation parameters", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("fails when changing optional to required query parameter", async () => {
+    it('fails when changing optional to required query parameter', async () => {
       const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
-      base.paths!["/example"]!.get!.parameters = [
+      base.paths!['/example']!.get!.parameters = [
         {
-          in: "query",
-          name: "query_parameter",
+          in: 'query',
+          name: 'query_parameter',
         },
       ];
       const result = await compare(base)
         .to((spec) => {
-          spec.paths!["/example"]!.get!.parameters = [
+          spec.paths!['/example']!.get!.parameters = [
             {
-              in: "query",
-              name: "query_parameter",
+              in: 'query',
+              name: 'query_parameter',
               required: true,
             },
           ];
@@ -264,34 +262,34 @@ describe("operation parameters", () => {
         })
         .withRule(
           rules.preventChangingOptionalToRequiredQueryParameters,
-          emptyContext
+          emptyContext,
         );
 
       expect(result.results[0].passed).toBeFalsy();
       expect(result).toMatchSnapshot();
     });
 
-    it("fails if the default value is changed", async () => {
+    it('fails if the default value is changed', async () => {
       const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
-      base.paths!["/example"]!.get!.parameters = [
+      base.paths!['/example']!.get!.parameters = [
         {
-          in: "query",
-          name: "query_parameter",
+          in: 'query',
+          name: 'query_parameter',
           schema: {
-            type: "string",
-            default: "before",
+            type: 'string',
+            default: 'before',
           },
         },
       ];
       const result = await compare(base)
         .to((spec) => {
-          spec.paths!["/example"]!.get!.parameters = [
+          spec.paths!['/example']!.get!.parameters = [
             {
-              in: "query",
-              name: "query_parameter",
+              in: 'query',
+              name: 'query_parameter',
               schema: {
-                type: "string",
-                default: "after",
+                type: 'string',
+                default: 'after',
               },
             },
           ];
@@ -304,17 +302,17 @@ describe("operation parameters", () => {
     });
   });
 
-  describe("status codes", () => {
-    it("fails when a status codes is removed", async () => {
+  describe('status codes', () => {
+    it('fails when a status codes is removed', async () => {
       const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
-      base.paths["/example"].get.responses = {
-        "200": {
-          description: "Example response",
+      base.paths['/example'].get.responses = {
+        '200': {
+          description: 'Example response',
         },
       };
       const result = await compare(base)
         .to((spec) => {
-          delete spec.paths!["/example"]!.get!.responses!["200"];
+          delete spec.paths!['/example']!.get!.responses!['200'];
           return spec;
         })
         .withRule(rules.preventRemovingStatusCodes, emptyContext);
@@ -324,8 +322,8 @@ describe("operation parameters", () => {
     });
   });
 
-  describe("version parameter", () => {
-    it("fails when there is no version parameter", async () => {
+  describe('version parameter', () => {
+    it('fails when there is no version parameter', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => spec)
         .withRule(rules.versionParameter, emptyContext);
@@ -334,13 +332,13 @@ describe("operation parameters", () => {
       expect(result).toMatchSnapshot();
     });
 
-    it("passes if there is a version parameter", async () => {
+    it('passes if there is a version parameter', async () => {
       const result = await compare(baseForOperationMetadataTests)
         .to((spec) => {
-          spec.paths!["/example"]!.get!.parameters = [
+          spec.paths!['/example']!.get!.parameters = [
             {
-              in: "query",
-              name: "version",
+              in: 'query',
+              name: 'version',
             },
           ];
           return spec;

--- a/src/rulesets/tests/operations.test.ts
+++ b/src/rulesets/tests/operations.test.ts
@@ -1,17 +1,8 @@
 import { rules } from "../operations";
-import { createTestDslFixture } from "@useoptic/api-checks";
 import { SnykApiCheckDsl, SynkApiCheckContext } from "../../dsl";
 
-const { compare } = createTestDslFixture<SnykApiCheckDsl, SynkApiCheckContext>(
-  (input) => {
-    return new SnykApiCheckDsl(
-      input.nextFacts,
-      input.changelog,
-      input.nextJsonLike,
-      input.context
-    );
-  }
-);
+import { createSnykTestFixture } from "./fixtures";
+const { compare } = createSnykTestFixture();
 
 const emptyContext: SynkApiCheckContext = {
   changeDate: "2021-10-10",
@@ -229,6 +220,106 @@ describe("operation parameters", () => {
         .withRule(rules.parameterCase, emptyContext);
 
       expect(result.results[0].passed).toBeTruthy();
+      expect(result).toMatchSnapshot();
+    });
+
+    it("fails when adding a required query parameter", async () => {
+      // const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
+      // base.paths!["/example"]!.get!.parameters = [];
+      const result = await compare(baseForOperationMetadataTests)
+        .to((spec) => {
+          spec.paths!["/example"]!.get!.parameters = [
+            {
+              in: "query",
+              name: "query_parameter",
+              required: true,
+            },
+          ];
+          return spec;
+        })
+        .withRule(rules.preventAddingRequiredQueryParameters, emptyContext);
+
+      expect(result.results[0].passed).toBeFalsy();
+      expect(result).toMatchSnapshot();
+    });
+
+    it("fails when changing optional to required query parameter", async () => {
+      const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
+      base.paths!["/example"]!.get!.parameters = [
+        {
+          in: "query",
+          name: "query_parameter",
+        },
+      ];
+      const result = await compare(base)
+        .to((spec) => {
+          spec.paths!["/example"]!.get!.parameters = [
+            {
+              in: "query",
+              name: "query_parameter",
+              required: true,
+            },
+          ];
+          return spec;
+        })
+        .withRule(
+          rules.preventChangingOptionalToRequiredQueryParameters,
+          emptyContext
+        );
+
+      expect(result.results[0].passed).toBeFalsy();
+      expect(result).toMatchSnapshot();
+    });
+
+    it("fails if the default value is changed", async () => {
+      const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
+      base.paths!["/example"]!.get!.parameters = [
+        {
+          in: "query",
+          name: "query_parameter",
+          schema: {
+            type: "string",
+            default: "before",
+          },
+        },
+      ];
+      const result = await compare(base)
+        .to((spec) => {
+          spec.paths!["/example"]!.get!.parameters = [
+            {
+              in: "query",
+              name: "query_parameter",
+              schema: {
+                type: "string",
+                default: "after",
+              },
+            },
+          ];
+          return spec;
+        })
+        .withRule(rules.preventChangingParameterDefaultValue, emptyContext);
+
+      expect(result.results[0].passed).toBeFalsy();
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe("status codes", () => {
+    it("fails when a status codes is removed", async () => {
+      const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
+      base.paths["/example"].get.responses = {
+        "200": {
+          description: "Example response",
+        },
+      };
+      const result = await compare(base)
+        .to((spec) => {
+          delete spec.paths!["/example"]!.get!.responses!["200"];
+          return spec;
+        })
+        .withRule(rules.preventRemovingStatusCodes, emptyContext);
+
+      expect(result.results[0].passed).toBeFalsy();
       expect(result).toMatchSnapshot();
     });
   });

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,5 +1,5 @@
-import { SnykApiCheckDsl, SynkApiCheckContext } from "./dsl";
-import { ApiCheckService, DslConstructorInput } from "@useoptic/api-checks";
+import { SnykApiCheckDsl, SynkApiCheckContext } from './dsl';
+import { ApiCheckService, DslConstructorInput } from '@useoptic/api-checks';
 
 export function newSnykApiCheckService() {
   const snykRulesService = new ApiCheckService<SynkApiCheckContext>();
@@ -8,22 +8,23 @@ export function newSnykApiCheckService() {
     return new SnykApiCheckDsl(
       input.nextFacts,
       input.changelog,
+      input.currentJsonLike,
       input.nextJsonLike,
-      input.context
+      input.context,
     );
   };
 
   snykRulesService.useDslWithNamedRules(
     dslConstructor,
-    require("./rulesets/operations").rules
+    require('./rulesets/operations').rules,
   );
   snykRulesService.useDslWithNamedRules(
     dslConstructor,
-    require("./rulesets/headers").rules
+    require('./rulesets/headers').rules,
   );
   snykRulesService.useDslWithNamedRules(
     dslConstructor,
-    require("./rulesets/properties").rules
+    require('./rulesets/properties').rules,
   );
 
   return snykRulesService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,12 +1319,12 @@
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@useoptic/api-checks@0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.3.3.tgz#d4664afee9cf79f1337f407c4c03307b3d4625a7"
-  integrity sha512-4cGsT+c7wlZxlxOpkzr3HUzdvJBdl6mno8AEvUy3/Ed1beAEH8GpmiyDYRzCAMA/ytnN/YEYh14xQf0UgM1FOQ==
+"@useoptic/api-checks@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.4.0.tgz#d036b3ffd5e58802c2b4983c7457ac53bc2ef0c9"
+  integrity sha512-/Z8+siwVySGeBOFEbEx2ol9LvU33o6M5PE7QpFFhAY6xrBJQ7pECgFMR1R21jQKf1cgNzxnVxRMf64Rk9kGMwA==
   dependencies:
-    "@useoptic/openapi-utilities" "0.3.3"
+    "@useoptic/openapi-utilities" "0.4.0"
     commander "^8.3.0"
     fs-extra "^10.0.0"
     ink "^3.2.0"
@@ -1336,10 +1336,10 @@
     react "^17.0.2"
     react-use "^17.3.1"
 
-"@useoptic/openapi-utilities@0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.3.3.tgz#b911b9bcb5ca42665ffe7f5e28b6a7dfeeadc694"
-  integrity sha512-WAs+hPIKSwFB3v+nlmXoggdoDJxqdAlQFYs1KJx77iJDOybDgW1dXSYL3QOG4w+8MeTIiDhc1GC27z1EFCH0lA==
+"@useoptic/openapi-utilities@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.4.0.tgz#18a4cc92a37143034f865c2ba8e39fe149c0c3c2"
+  integrity sha512-zsJHpMfJzaodxVjNTvK1N1LYnikJx4txLC5WERnXhIvT55juylJYzBqspTBlZG+xRc3kPTHcpyWBQBfNqO0BeA==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@jsdevtools/ono" "^7.1.3"
@@ -1347,7 +1347,6 @@
     fast-deep-equal "^3.1.3"
     fs-extra "^10.0.0"
     json-pointer "^0.6.1"
-    json-ptr "^2.2.0"
     lodash.sortby "^4.7.0"
     micro "^9.3.4"
     micro-cors "^0.1.1"
@@ -3418,13 +3417,6 @@ json-pointer@^0.6.1:
   dependencies:
     foreach "^2.0.4"
 
-json-ptr@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json-ptr/-/json-ptr-2.2.0.tgz#a4de4ed638cb23ae4cd4b51f8bf972a1c2293f1e"
-  integrity sha512-w9f6/zhz4kykltXMG7MLJWMajxiPj0q+uzQPR1cggNAE/sXoq/C5vjUb/7QNcC3rJsVIIKy37ALTXy1O+3c8QQ==
-  dependencies:
-    tslib "^2.2.0"
-
 json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
@@ -4862,7 +4854,7 @@ ts-node@^10.4.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
-tslib@^2.1.0, tslib@^2.2.0:
+tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,26 +1319,27 @@
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@useoptic/api-checks@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.3.2.tgz#7e674ac6c04aa84966e8a2b04bc5da1fd8c7e268"
-  integrity sha512-ACsyjz9oFapdTvh5J3wkNDZ1Z0Cvpc9CT2msqAkmv2VJUl5fnwWW7C2Xlw3sbsPS7yLlaiGdkm/dPnaMzfunIA==
+"@useoptic/api-checks@0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.3.3.tgz#d4664afee9cf79f1337f407c4c03307b3d4625a7"
+  integrity sha512-4cGsT+c7wlZxlxOpkzr3HUzdvJBdl6mno8AEvUy3/Ed1beAEH8GpmiyDYRzCAMA/ytnN/YEYh14xQf0UgM1FOQ==
   dependencies:
-    "@useoptic/openapi-utilities" "0.3.2"
+    "@useoptic/openapi-utilities" "0.3.3"
     commander "^8.3.0"
     fs-extra "^10.0.0"
     ink "^3.2.0"
     ink-link "^2.0.0"
     ink-testing-library "^2.1.0"
+    jsonpath "^1.1.1"
     lodash.flatten "^4.4.0"
     lodash.groupby "^4.6.0"
     react "^17.0.2"
     react-use "^17.3.1"
 
-"@useoptic/openapi-utilities@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.3.2.tgz#6c253613ce4f7a72bed1a5e88dfd89570bef9b27"
-  integrity sha512-hFdMNuR0kbocbXd0H/FLS/WpTvkHRNr/YVnG2YoEiuYSQgIW6qw4Mr2tXz2a6SE6OlWa+Rz9ghATBW9Ex96d0Q==
+"@useoptic/openapi-utilities@0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.3.3.tgz#b911b9bcb5ca42665ffe7f5e28b6a7dfeeadc694"
+  integrity sha512-WAs+hPIKSwFB3v+nlmXoggdoDJxqdAlQFYs1KJx77iJDOybDgW1dXSYL3QOG4w+8MeTIiDhc1GC27z1EFCH0lA==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@jsdevtools/ono" "^7.1.3"
@@ -2210,6 +2211,18 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+escodegen@^1.8.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 escodegen@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
@@ -2222,10 +2235,20 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+esprima@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.2.tgz#76a0fd66fcfe154fd292667dc264019750b1657b"
+  integrity sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs=
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+estraverse@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.2.0:
   version "5.3.0"
@@ -3430,6 +3453,15 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonpath@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.1.1.tgz#0ca1ed8fb65bb3309248cc9d5466d12d5b0b9901"
+  integrity sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==
+  dependencies:
+    esprima "1.2.2"
+    static-eval "2.0.2"
+    underscore "1.12.1"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -4594,6 +4626,13 @@ stacktrace-js@^2.0.2:
     stack-generator "^2.0.5"
     stacktrace-gps "^3.0.4"
 
+static-eval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  dependencies:
+    escodegen "^1.8.1"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -4871,6 +4910,11 @@ typescript@^4.4.4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
A PR of the latest we've completed, today's batch, all about how parameters can change between versions. The `.changed` functions really shine here