### PR TITLE
chore: Improve example common schema, refine property rules

### DIFF
--- a/end-end-tests/api-standards/components/common.yaml
+++ b/end-end-tests/api-standards/components/common.yaml
@@ -3,8 +3,13 @@ JsonApi:
   properties:
     version:
       type: string
+      format: semver
+      description: Version of the JSON API specification this server supports.
+      example: "1.0"
   required: ['version']
   additionalProperties: false
+  example:
+    version: "1.0"
 
 Links:
   type: object
@@ -41,30 +46,56 @@ PaginatedLinks:
 LinkProperty:
   oneOf:
     - type: string
+      description: A string containing the link’s URL.
+      example: "https://example.com/api/resource"
     - type: object
       properties:
         href:
           type: string
+          format: url
+          description: A string containing the link’s URL.
+          example: "https://example.com/api/resource"
         meta: { $ref: '#/Meta' }
       required: [ 'href' ]
       additionalProperties: false
+      example:
+        href: "https://example.com/api/resource"
+  example: "https://example.com/api/resource"
 
 Meta:
   type: object
+  description: Free-form object that may contain non-standard information.
+  example:
+    key1: value1
+    key2:
+      sub_key: sub_value
+    key3: [array_value1, array_value2]
   additionalProperties: true
 
 Relationship:
   type: object
   properties:
     data:
+      type: object
       properties:
         type:
           type: string
+          format: resource-type
+          description: Type of the related resource
+          example: resource
         id:
           type: string
           format: uuid
+          example: 4a72d1db-b465-4764-99e1-ecedad03b06a
       required: ['type', 'id']
       additionalProperties: false
-    links: { $ref: '#/RelatedLink' }
+    link: { $ref: '#/RelatedLink' }
     meta: { $ref: '#/Meta' }
-  required: [data, links]
+  required: [data, link]
+  example:
+    data:
+      type: resource
+      id: 4a72d1db-b465-4764-99e1-ecedad03b06a
+    link:
+      related:
+        href: https://example.com/api/resource/4a72d1db-b465-4764-99e1-ecedad03b06a

--- a/end-end-tests/api-standards/components/errors.yaml
+++ b/end-end-tests/api-standards/components/errors.yaml
@@ -6,8 +6,17 @@ ErrorDocument:
       type: array
       items: { $ref: '#/Error' }
       minItems: 1
+      example:
+        - status: "403"
+          detail: Permission denied for this resource
   additionalProperties: false
   required: [ 'jsonapi', 'errors']
+  example:
+    jsonapi:
+      version: "1.0"
+    errors:
+      - status: "403"
+        detail: Permission denied for this resource
 
 Error:
   type: object
@@ -15,20 +24,41 @@ Error:
     id:
       type: string
       format: uuid
+      description: "A unique identifier for this particular occurrence of the problem."
+      example: f16c31b5-6129-4571-add8-d589da9be524
     status:
       type: string
+      pattern: '^[45]\d\d$'
+      description: "The HTTP status code applicable to this problem, expressed as a string value."
+      example: "400"
     detail:
       type: string
+      format: user-text
+      description: "A human-readable explanation specific to this occurrence of the problem."
+      example: "The request was missing these required fields: ..."
     source:
       type: object
       properties:
         pointer:
           type: string
+          format: path
+          description: "A JSON Pointer [RFC6901] to the associated entity in the request document."
+          example: /data/attributes
         parameter:
           type: string
+          format: parameter
+          description: "A string indicating which URI query parameter caused the error."
+          example: "param1"
       additionalProperties: false
+      example:
+        pointer: /data/attributes
     meta:
       type: object
       additionalProperties: true
+      example:
+        key: value
   required: ['status', 'detail']
   additionalProperties: false
+  example:
+    status: "404"
+    detail: "Not Found"

--- a/end-end-tests/api-standards/components/types.yaml
+++ b/end-end-tests/api-standards/components/types.yaml
@@ -1,3 +1,5 @@
 Types:
   type: string
+  format: resource-type
+  example: resource
   # TODO: enum, generated from all known resources

--- a/end-end-tests/api-standards/resources/thing/2021-11-10/000-baseline.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/000-baseline.yaml
@@ -193,6 +193,7 @@ components:
       properties:
         name:
           type: string
+          format: user-text
           description: Name of this instance of thing.
           example: thing
         created:
@@ -207,6 +208,7 @@ components:
           example: '2021-10-05T13:25:29Z'
         description:
           type: string
+          format: user-text
           description: User-friendly description of this instance of thing.
           example: "This is a thing named thing."
       additionalProperties: false

--- a/src/rulesets/properties.ts
+++ b/src/rulesets/properties.ts
@@ -1,5 +1,24 @@
 import { SnykApiCheckDsl } from "../dsl";
 const { expect } = require("chai");
+
+const oas3Formats = [
+  "date",
+  "date-time",
+  "password",
+  "byte",
+  "binary",
+];
+
+const allowedFormats = Array.prototype.concat(oas3Formats, [
+  "uuid",
+  "semver",
+  "url",
+  "parameter",
+  "path",
+  "user-text",
+  "resource-type",
+]);
+
 export const rules = {
   propertyKey: ({ bodyProperties }: SnykApiCheckDsl) => {
     bodyProperties.requirement.must("have camel case keys", ({ key }) => {
@@ -9,7 +28,9 @@ export const rules = {
   },
   propertyExample: ({ bodyProperties }: SnykApiCheckDsl) => {
     bodyProperties.requirement.must("have an example", ({ flatSchema }) => {
-      expect(flatSchema.example).to.exist;
+      if (flatSchema?.type !== "object" && flatSchema?.type !== "array") {
+        expect(flatSchema.example).to.exist;
+      }
     });
   },
   propertyFormat: ({ bodyProperties }: SnykApiCheckDsl) => {
@@ -17,7 +38,11 @@ export const rules = {
       "have a format when a string",
       ({ flatSchema }) => {
         if (flatSchema.type === "string") {
-          expect(flatSchema.format).to.exist;
+          if (flatSchema.format) {
+            expect(flatSchema.format).to.be.oneOf(allowedFormats);
+          } else {
+            expect(flatSchema.pattern).to.exist;
+          }
         }
       }
     );


### PR DESCRIPTION
This change improves the common schema types referenced in the
end-end-tests/api-standards test fixtures / examples, with some rule
refinements:

- Specifying examples for object and array types can be tedious when
  objects are nested. We should allow for object examples, but if all
  the simple-typed properties have examples and formats, documentation
  generation (such as ReDoc) can infer what an example request or
  response should look like.
- Requiring format types are great, but we need more of them in order
  for spec authors to be able to write reasonable specs. Defining a few
  core formats we will need. We should limit these to a pre-defined set
  of supported formats, because tooling will need to understand these
  and validate them. Also introducing a break-glass feature where the
  spec author can provide a regex pattern as an alternative to a
  pre-defined format.

The 000-baseline spec now passes rules. It also passes spectral's oas3
ruleset.

Draft because the rule changes need tests updated.