### PR TITLE
fix: common and errors types

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -98,7 +98,7 @@ Relationship:
       additionalProperties: false
     links: { $ref: '#/RelatedLink' }
     meta: { $ref: '#/Meta' }
-  required: [data, link]
+  required: [data, links]
   example:
     data:
       type: resource

--- a/errors.yaml
+++ b/errors.yaml
@@ -44,7 +44,6 @@ Error:
           example: /data/attributes
         parameter:
           type: string
-          pattern: '^[a-z][a-z0-9]*(_[a-z][a-z0-9]*)*$'
           description: "A string indicating which URI query parameter caused the error."
           example: "param1"
       additionalProperties: false


### PR DESCRIPTION
Removing Error parameter constraint for now, some active APIs are using
parameters that pre-date parameter snake case rules.

Fix required properties on Relationship.