### PR TITLE
perf: optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM node:14-alpine
+FROM node:14-alpine AS build
 ENV NODE_ENV=development
 WORKDIR /usr/src/sweater-comb
 COPY ["package.json", "yarn.lock", "./"]
 RUN yarn install
 COPY . .
 RUN yarn build
-USER node
-ENV NODE_PATH /usr/src/sweater-comb
-VOLUME /target
-WORKDIR /target
-ENTRYPOINT [ "node", "/usr/src/sweater-comb/build/index.js" ]
+
+FROM node:14-alpine AS clean
+WORKDIR /usr/src/sweater-comb
+COPY --from=build /usr/src/sweater-comb/package*.json ./
+COPY --from=build /usr/src/sweater-comb/build ./
+RUN npm install --only=production
+
+FROM gcr.io/distroless/nodejs:14
+WORKDIR /usr/lib/sweater-comb
+COPY --from=clean /usr/src/sweater-comb ./
+USER 1000
+CMD ["index.js"]

--- a/end-end-tests/api-standards/test.bash
+++ b/end-end-tests/api-standards/test.bash
@@ -5,13 +5,15 @@ cd $HERE/../..
 
 CONTEXT=$(awk NF=NF RS= OFS= <$HERE/context.json)
 
+COMPARE=${COMPARE:-yarn run compare}
+
 # These should pass
 
-yarn run compare \
+${COMPARE} \
     --from $HERE/resources/thing/2021-11-10/000-baseline.yaml \
     --to $HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml \
     --context "${CONTEXT}"
-yarn run compare \
+${COMPARE} \
     --from $HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml \
     --to $HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml \
     --context "${CONTEXT}"
@@ -23,7 +25,7 @@ FAILING_CHANGES="\
     $HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml \
     $HERE/resources/thing/2021-11-10/001-fail-operation-removed.yaml"
 for fc in ${FAILING_CHANGES}; do
-    yarn run compare \
+    ${COMPARE} \
         --from $HERE/resources/thing/2021-11-10/000-baseline.yaml \
         --to ${fc} \
         --context "${CONTEXT}" \

--- a/scripts/run-docker.bash
+++ b/scripts/run-docker.bash
@@ -3,4 +3,4 @@
 set -eu
 cd $(dirname $0)/..
 
-docker run --rm -it -v $(pwd):/target docker.io/snyk/sweater-comb:optic-latest "$@"
+docker run --rm -it -v $(pwd):$(pwd) docker.io/snyk/sweater-comb:optic-latest "$@"


### PR DESCRIPTION
Reduce the size of the Docker image by including only the compiled JS
and using a distroless base.

Parameterize e2e test script to better evaluate performance of different
run configurations.