### PR TITLE
feat: add bulk-compare script, more tests

### DIFF
--- a/end-end-tests/api-standards/test-bulk.bash
+++ b/end-end-tests/api-standards/test-bulk.bash
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -eu
+HERE=$(cd $(dirname $0); pwd)
+cd $HERE/../..
+
+CONTEXT=$(awk NF=NF RS= OFS= <$HERE/context.json)
+
+COMPARE=${COMPARE:-yarn run bulk-compare}
+
+good_input=$(mktemp)
+bad_input=$(mktemp)
+trap "rm -f $good_input $bad_input" EXIT
+
+cat >$good_input <<EOF
+{
+    "comparisons": [{
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml", "to": "$HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }]
+}
+EOF
+
+cat >$bad_input <<EOF
+{
+    "comparisons": [{
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-breaking-param-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-format-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-operation-removed.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-stability-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-type-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml", "to": "$HERE/resources/thing/2021-11-10/003-fail-type-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+    }]
+}
+EOF
+
+${COMPARE} --input $good_input
+${COMPARE} --input $bad_input && false || true

--- a/end-end-tests/api-standards/test.bash
+++ b/end-end-tests/api-standards/test.bash
@@ -18,12 +18,21 @@ ${COMPARE} \
     --to $HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml \
     --context "${CONTEXT}"
 
+# This should fail
+${COMPARE} \
+    --from $HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml \
+    --to $HERE/resources/thing/2021-11-10/003-fail-type-change.yaml \
+    --context "${CONTEXT}" \
+    && false || true
+
 # These should fail
 FAILING_CHANGES="\
     $HERE/resources/thing/2021-11-10/001-fail-stability-change.yaml \
     $HERE/resources/thing/2021-11-10/001-fail-breaking-param-change.yaml \
     $HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml \
-    $HERE/resources/thing/2021-11-10/001-fail-operation-removed.yaml"
+    $HERE/resources/thing/2021-11-10/001-fail-operation-removed.yaml \
+    $HERE/resources/thing/2021-11-10/001-fail-format-change.yaml \
+    "
 for fc in ${FAILING_CHANGES}; do
     ${COMPARE} \
         --from $HERE/resources/thing/2021-11-10/000-baseline.yaml \

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "yarn tsc --build --verbose",
     "clean": "rm -rf build",
     "compare": "yarn ts-node src/index.ts compare",
+    "bulk-compare": "yarn ts-node src/index.ts bulk-compare",
     "lint": "run-p lint:*",
     "lint:formatting": "prettier --check 'src/**/*.{js,ts}'",
     "format": "prettier --write 'src/**/*.{js,ts}'"


### PR DESCRIPTION
This adds a yarn run script for driving bulk-compare, an e2e test for
bulk-compare using existing fixtures, and a missing fixture in the
original e2e test script.