### PR TITLE
chore: demonstrate issue w/failing rules and changes

### DIFF
--- a/end-end-tests/api-standards/context.json
+++ b/end-end-tests/api-standards/context.json
@@ -1,5 +1,9 @@
 {
   "changeDate": "2021-11-11",
   "changeResource": "thing",
-  "changeVersion": "2021-11-10"
+  "changeVersion": {
+    "date": "2021-11-10",
+    "stability": "experimental"
+  },
+  "resourceVersionReleases": {}
 }

--- a/end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-naming.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-naming.yaml
@@ -1,0 +1,289 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: v3
+  version: 3.0.0
+servers:
+  - url: https://api.snyk.io/v3
+    description: Public Snyk API
+tags:
+  - name: Thing
+    description: Short description of what Thing represents
+paths:
+  /orgs/{org_id}/thing:
+    post:
+      summary: Create a new thing
+      description: Create a new thing
+      operationId: makeThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+      responses:
+        "201":
+          description: Created thing successfully
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "409": { $ref: "../../../../../components/responses/409.yaml#/409" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+    get:
+      summary: List instances of thing
+      description: List instances of thing
+      operationId: listThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+      responses:
+        "200":
+          description: Returns a list of thing instances
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingCollectionResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+  /orgs/{org_id}/thing/{thing_id}:
+    get:
+      summary: Get an instance of thing
+      description: Get an instance of thing
+      operationId: getThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Returns an instance of thing
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+    patch:
+      summary: Update an instance of thing
+      description: Update an instance of thing
+      operationId: updateThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Instance of thing is updated.
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "204": { $ref: "../../../../../components/responses/204.yaml#/204" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "409": { $ref: "../../../../../components/responses/409.yaml#/409" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+    delete:
+      summary: Delete an instance of thing
+      description: Delete an instance of thing
+      operationId: deleteThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "204": { $ref: "../../../../../components/responses/204.yaml#/204" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "409": { $ref: "../../../../../components/responses/409.yaml#/409" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+components:
+  parameters:
+    OrgId:
+      name: orgId
+      in: path
+      required: true
+      description: Org ID
+      schema:
+        type: string
+        format: uuid
+    ThingId:
+      name: thingId
+      in: path
+      required: true
+      description: Unique identifier for thing instances
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    ThingResourceResponse:
+      type: object
+      description: Response containing a single thing resource object
+      properties:
+        jsonapi: { $ref: "../../../../../components/common.yaml#/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingResource" }
+        links: { $ref: "../../../../../components/common.yaml#/SelfLink" }
+
+    ThingCollectionResponse:
+      type: object
+      description: Response containing a collection of thing resource objects
+      properties:
+        jsonapi: { $ref: "../../../../../components/common.yaml#/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingCollection" }
+        links: { $ref: "../../../../../components/common.yaml#/PaginatedLinks" }
+
+    ThingResource:
+      type: object
+      description: thing resource object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+        type: { $ref: "../../../../../components/types.yaml#/Types" }
+        attributes: { $ref: "#/components/schemas/ThingAttributes" }
+        relationships: { $ref: "#/components/schemas/ThingRelationships" }
+      additionalProperties: false
+
+    ThingRelationships:
+      type: object
+      properties:
+        example: { $ref: "../../../../../components/common.yaml#/Relationship" }
+      additionalProperties: false
+
+    ThingCollection:
+      type: array
+      items: { $ref: "#/components/schemas/ThingResource" }
+
+    ThingAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of this instance of thing.
+          example: thing
+        created:
+          type: string
+          description: Timestamp when this instance of thing was created.
+          format: date-time
+          example: "2021-10-05T13:23:17Z"
+        updated:
+          type: string
+          description: Timestamp when this instance of thing was last updated.
+          format: date-time
+          example: "2021-10-05T13:25:29Z"
+        userDescription:
+          type: string
+          description: User-friendly description of this instance of thing.
+          example: "This is a thing named thing."
+      additionalProperties: false

--- a/end-end-tests/api-standards/test-bulk.bash
+++ b/end-end-tests/api-standards/test-bulk.bash
@@ -14,9 +14,11 @@ trap "rm -f $good_input $bad_input" EXIT
 cat >$good_input <<EOF
 {
     "comparisons": [{
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml", "to": "$HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml", "to": "$HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-fail-naming.yaml", "to": "$HERE/resources/thing/2021-11-10/000-fail-naming.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }]
 }
 EOF
@@ -24,19 +26,21 @@ EOF
 cat >$bad_input <<EOF
 {
     "comparisons": [{
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-breaking-param-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "to": "$HERE/resources/thing/2021-11-10/000-fail-naming.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-format-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-breaking-param-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-operation-removed.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-format-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-operation-removed.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-stability-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-type-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-stability-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
-        "from": "$HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml", "to": "$HERE/resources/thing/2021-11-10/003-fail-type-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": "2021-11-10"}
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-fail-type-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml", "to": "$HERE/resources/thing/2021-11-10/003-fail-type-change.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }]
 }
 EOF

--- a/end-end-tests/api-standards/test.bash
+++ b/end-end-tests/api-standards/test.bash
@@ -4,6 +4,7 @@ HERE=$(cd $(dirname $0); pwd)
 cd $HERE/../..
 
 CONTEXT=$(awk NF=NF RS= OFS= <$HERE/context.json)
+echo $CONTEXT
 
 COMPARE=${COMPARE:-yarn run compare}
 
@@ -17,15 +18,23 @@ ${COMPARE} \
     --from $HERE/resources/thing/2021-11-10/001-ok-add-property-field.yaml \
     --to $HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml \
     --context "${CONTEXT}"
+${COMPARE} \
+    --to $HERE/resources/thing/2021-11-10/000-fail-naming.yaml \
+    --context "${CONTEXT}"
 
-# This should fail
+# These should fail
+
+${COMPARE} \
+    --to $HERE/resources/thing/2021-11-10/000-fail-naming.yaml \
+    --context "${CONTEXT}" \
+    && false || true
+
 ${COMPARE} \
     --from $HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml \
     --to $HERE/resources/thing/2021-11-10/003-fail-type-change.yaml \
     --context "${CONTEXT}" \
     && false || true
 
-# These should fail
 FAILING_CHANGES="\
     $HERE/resources/thing/2021-11-10/001-fail-stability-change.yaml \
     $HERE/resources/thing/2021-11-10/001-fail-breaking-param-change.yaml \


### PR DESCRIPTION
In order to be able to introduce Optic into a project, it should
only apply rules to changes between specs. This allows Optic to be
introduced into a new project which may not yet conform to all the
standards. New changes to specs must meet these standards, but existing
specs should not fail CI.

This change introduces a spec that violates naming conventions, which
should fail if introduced as new (--to 000-fail-naming.yaml with no
--from) but should pass if compared against itself (no change means no
violating change).