### PR TITLE
chore: update CircleCI release configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ defaults: &defaults
   docker:
     - image: circleci/node:14-buster
   working_directory: ~/sweater-comb
+  environment:
+    IMAGE: ghcr.io/snyk/sweater-comb
 
 jobs:
   test:
@@ -26,7 +28,7 @@ jobs:
           name: E2E Test
           command: ./end-end-tests/api-standards/test-bulk.bash
 
-  docker-main-release:
+  docker-release:
     <<: *defaults
     steps:
       - checkout
@@ -34,14 +36,27 @@ jobs:
           version: '20.10.7'
       - run:
           name: Build Docker image
-          command: IMAGE=ghcr.io/snyk/sweater-comb TAG=optic-main ./scripts/build-docker.bash
+          environment:
+            GIT_BRANCH: << pipeline.git.branch >>
+            GIT_TAG: << pipeline.git.tag >>
+          command: |-
+            export TAG=${GIT_TAG:-${GIT_BRANCH}}
+            [ -n "$IMAGE" ] || exit 1
+            [ -n "$TAG" ] || exit 1
+            ./scripts/build-docker.bash'
       - run:
           name: Push Docker image
+          environment:
+            GIT_BRANCH: << pipeline.git.branch >>
+            GIT_TAG: << pipeline.git.tag >>
           command: |-
+            [ -n "$IMAGE" ] || exit 1
+            export TAG=${GIT_TAG:-${GIT_BRANCH}}
+            [ -n "$TAG" ] || exit 1
             echo "${GHCR_TOKEN}" | docker login ghcr.io -u snyk --password-stdin
-            docker push ghcr.io/snyk/sweater-comb:optic-main
+            docker push ${IMAGE}:${TAG}
 
-  npm-main-release:
+  npm-release:
     <<: *defaults
     steps:
       - checkout
@@ -58,11 +73,21 @@ workflows:
     jobs:
       - test:
           name: Test
-      - docker-main-release:
-          name: Docker Image Release - Main
+      - docker-release:
+          name: Docker Image Release
           requires:
             - Test
           filters:
             branches:
+              only: 'main'
+            tags:
               only:
-                - optic-main
+                - /^v.*/
+      - npm-release:
+          name: NPM Release - Tag
+          requires:
+            - Test
+          filters:
+            tags:
+              only:
+                - /^v.*/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "bin": {
-    "sweater-comb": "bin/sweater-comb"
+    "sweater-comb": "build/index.js"
   },
   "files": [
     "/build"

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -1,2 +1,3 @@
-export TAG=${TAG:-optic-main}
+export TAG=${TAG:-main}
+export LATEST_GIT_TAG=$(git describe --tags --abbrev=0)
 export IMAGE=${IMAGE:-ghcr.io/snyk/sweater-comb}

--- a/scripts/release-docker.bash
+++ b/scripts/release-docker.bash
@@ -6,4 +6,6 @@ cd $(dirname $0)/..
 scripts/build-docker.bash
 
 docker push ${IMAGE}:${TAG}
-docker push ${IMAGE}:latest
+if [[ "${TAG}" == "${LATEST_GIT_TAG}" ]]; then
+  docker push ${IMAGE}:latest
+fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { makeCiCli } from "@useoptic/api-checks/build/ci-cli/make-cli";
 import { newSnykApiCheckService } from "./service";
 


### PR DESCRIPTION
This updates CircleCI automated releases to:
- Publish to NPM only on pushed tags
- Publish to Docker on pushed tags and landing in main
- Update the Docker latest tag when the image tag is the latest git
  tag (new tag release).