### PR TITLE
fix: npm package script, semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,24 +66,18 @@ workflows:
     jobs:
       - test:
           name: Test
-          filters:
-            # In CircleCI, branches are on by default and do not need to be specified.
-            # However tags are off by default and need to be specified.
-            tags:
-              only: '/^v.*$/'
-      - docker-release:
-          name: Docker Image Release
-          requires:
-            - Test
-          filters:
-            branches:
-              only: 'main'
-            tags:
-              only: '/^v.*$/'
       - npm-release:
           name: NPM Release - Tag
           requires:
             - Test
+          context: nodejs-app-release
+          filters:
+            branches:
+              only: 'main'
+  docker_publish:
+    jobs:
+      - docker-release:
+          name: Docker Image Release
           filters:
             branches:
               ignore: '/.*/'

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@snyk/sweater-comb",
   "packageManager": "yarn@3.0.2",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "bin": {
-    "sweater-comb": "build/index.js"
+    "sweater-comb": "scripts/sweater-comb.js"
   },
   "files": [
     "/build"

--- a/scripts/sweater-comb.js
+++ b/scripts/sweater-comb.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');


### PR DESCRIPTION
This fixes the configured "binary" script that should be installed into
node_modules/.bin.

Adding the shebang to build/index.js directly (via src/index.ts) seems
to break the Docker build, so a separate wrapper script was needed.

This also fixes semantic release. semantic-release creates a tag and
publishes to npm, the tag then triggers a docker build.