### PR TITLE
fix: npm build and semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,14 +54,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install
-          command: yarn install
-      - run:
-          name: Build
-          command: yarn build
-      - run:
-          name: Release
-          command: yarn semantic-release
+          name: Build and release
+          command: ./scripts/build-npm.bash
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "bin": {
-    "sweater-comb": "scripts/sweater-comb.js"
+    "sweater-comb": "build/index.js"
   },
   "files": [
     "/build"
@@ -43,13 +43,19 @@
     "@useoptic/json-pointer-helpers": "0.15.9",
     "@useoptic/openapi-io": "0.15.9",
     "@useoptic/openapi-utilities": "0.15.9",
-    "ajv": "^8.8.2",
     "chai": "^4.3.4",
     "change-case": "^4.1.2",
     "fs-extra": "^10.0.0",
     "nice-try": "^3.0.0",
     "yargs": "^17.3.0"
   },
+  "bundledDependencies": [
+    "@stoplight/spectral-rulesets",
+    "@useoptic/api-checks",
+    "@useoptic/json-pointer-helpers",
+    "@useoptic/openapi-io",
+    "@useoptic/openapi-utilities"
+  ],
   "jest": {
     "testPathIgnorePatterns": [
       "build"

--- a/scripts/build-npm.bash
+++ b/scripts/build-npm.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eux
+cd $(dirname $0)/..
+
+# Stage 1: clean install of dev dependencies, build TS
+rm -rf node_modules
+yarn install
+yarn clean
+yarn build
+npm pack
+
+if [[ -n "$GITHUB_TOKEN" && -n "$NPM_TOKEN" ]]; then
+  npx semantic-release
+fi

--- a/scripts/sweater-comb.js
+++ b/scripts/sweater-comb.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../build/index.js');

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -407,44 +407,45 @@ export class SnykApiCheckDsl implements ApiCheckDsl {
       docs: DocsLinkHelper,
     ) => void
   > {
-    const contextChangedHandler: (must: boolean) => ContextChangedRule["must"] =
-      (must: boolean) => {
-        return (statement, handler) => {
-          const docsHelper = newDocsLinkHelper();
-          const syntheticChange: IChange<any> = {
-            added: this.providedContext,
-            changeType: ChangeType.Added,
-            location: {
-              jsonPath: "/",
-              conceptualPath: [],
-              conceptualLocation: {
-                path: "Entire Resource",
-                method: "",
-              },
-              kind: "ContextRule",
-            } as any,
-          };
-          this.checks.push(
-            runCheck(
-              syntheticChange,
-              docsHelper,
-              "api lifeycle: ",
-              statement,
-              must,
-              () =>
-                handler(
-                  {
-                    ...this.providedContext,
-                    wasDeleted: Boolean(
-                      this.nextJsonLike["x-optic-ci-empty-spec"],
-                    ),
-                  },
-                  docsHelper,
-                ),
-            ),
-          );
+    const contextChangedHandler: (
+      must: boolean,
+    ) => ContextChangedRule["must"] = (must: boolean) => {
+      return (statement, handler) => {
+        const docsHelper = newDocsLinkHelper();
+        const syntheticChange: IChange<any> = {
+          added: this.providedContext,
+          changeType: ChangeType.Added,
+          location: {
+            jsonPath: "/",
+            conceptualPath: [],
+            conceptualLocation: {
+              path: "Entire Resource",
+              method: "",
+            },
+            kind: "ContextRule",
+          } as any,
         };
+        this.checks.push(
+          runCheck(
+            syntheticChange,
+            docsHelper,
+            "api lifeycle: ",
+            statement,
+            must,
+            () =>
+              handler(
+                {
+                  ...this.providedContext,
+                  wasDeleted: Boolean(
+                    this.nextJsonLike["x-optic-ci-empty-spec"],
+                  ),
+                },
+                docsHelper,
+              ),
+          ),
+        );
       };
+    };
 
     return {
       must: contextChangedHandler(true),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { makeCiCli } from "@useoptic/api-checks/build/ci-cli/make-cli";
 import { newSnykApiCheckService } from "./service";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,7 +1858,7 @@ ajv-formats@~2.1.0:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^8.0.0, ajv@^8.8.2:
+ajv@^8.0.0:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
   integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==


### PR DESCRIPTION
Ok, this seems to fix issues with sweater-comb not being
npm-installable.

Queue: "Fantasic Voyage"...

So what I found when `yarn pack`ing this package was:
- It can be `yarn add`ed to yarn projects just fine and sweater-comb /
  optic works.
- It cannot be `npm install`ed into npm projects. The ajv module was
  failing to initialize, which is what the past few 1.0.1-present
  releases were trying to fix.

The root cause seems to be that npm seems to pick the wrong ajv version,
but yarn gets it right. ajv is a transitive dependency, pulled in via
the spectral rules support at the very least.

This tool needs to be used in an npm-based project, so "just use yarn"
wouldn't be an acceptable limitation. I found a workaround:

- Bundling all the Spectral and Optic dependencies seems to satisfy
  `npm install`, and the sweater-comb script works!
- `yarn pack` can't deal with bundling dependencies, it bombs out in the
  presence of them, and the project seems to declare it a won't fix
  situation.

Queue: "Stuck in the middle with you"...

So what this does is:
- In `package.json`, bundle the dependencies that npm will otherwise break.
- Build this project with yarn.
- Pack it with `npm pack`.
- Release it with npx semantic-release, which is npm-friendly.

I've tested sweater-comb works when `npm install`/`yarn add` -ed to
projects managed with each.

Other changes in this PR are undo-ing the cargo-culting I was doing in
trying to appease the node module loader.