### PR TITLE
Update optic 0.22.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@useoptic/api-checks": "0.21.3",
-    "@useoptic/json-pointer-helpers": "0.21.3",
-    "@useoptic/openapi-io": "0.21.3",
-    "@useoptic/openapi-utilities": "0.21.3",
+    "@useoptic/api-checks": "0.22.4",
+    "@useoptic/json-pointer-helpers": "0.22.4",
+    "@useoptic/openapi-io": "0.22.4",
+    "@useoptic/openapi-utilities": "0.22.4",
     "chai": "^4.3.4",
     "change-case": "^4.1.2",
     "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@useoptic/api-checks": "0.22.4",
-    "@useoptic/json-pointer-helpers": "0.22.4",
-    "@useoptic/openapi-io": "0.22.4",
-    "@useoptic/openapi-utilities": "0.22.4",
+    "@useoptic/api-checks": "0.22.5",
+    "@useoptic/json-pointer-helpers": "0.22.5",
+    "@useoptic/openapi-io": "0.22.5",
+    "@useoptic/openapi-utilities": "0.22.5",
     "chai": "^4.3.4",
     "change-case": "^4.1.2",
     "fs-extra": "^10.0.0",

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -29,11 +29,11 @@ export async function changeLogBetween(
 ): Promise<IChange<OpenApiFact>[]> {
   const currentTraverser = new OpenAPITraverser();
   currentTraverser.traverse(from);
-  const currentFacts = [...(currentTraverser.facts())];
+  const currentFacts = [...currentTraverser.facts()];
 
   const nextTraverser = new OpenAPITraverser();
   nextTraverser.traverse(to);
-  const nextFacts = [...(nextTraverser.facts())];
+  const nextFacts = [...nextTraverser.facts()];
 
   return factsToChangelog(currentFacts, nextFacts);
 }

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -29,11 +29,11 @@ export async function changeLogBetween(
 ): Promise<IChange<OpenApiFact>[]> {
   const currentTraverser = new OpenAPITraverser();
   currentTraverser.traverse(from);
-  const currentFacts = currentTraverser.accumulator.allFacts();
+  const currentFacts = [...(currentTraverser.facts())];
 
   const nextTraverser = new OpenAPITraverser();
   nextTraverser.traverse(to);
-  const nextFacts = nextTraverser.accumulator.allFacts();
+  const nextFacts = [...(nextTraverser.facts())];
 
   return factsToChangelog(currentFacts, nextFacts);
 }

--- a/src/rulesets/jsonapi.ts
+++ b/src/rulesets/jsonapi.ts
@@ -81,7 +81,8 @@ export const rules = {
       "use the JSON:API content type",
       (response, context, docs, specItem) => {
         docs.includeDocsLink(links.jsonApi.contentType);
-        if (isOpenApiPath(context.path) || response.statusCode === 204) return;
+        if (isOpenApiPath(context.path) || response.statusCode === "204")
+          return;
         const contentTypes = Object.keys(specItem.content);
         expect(
           contentTypes,
@@ -103,7 +104,7 @@ export const rules = {
         const responseName = getResponseName(response, context);
 
         // Patch response requires schema
-        if (context.method === "patch" && response.statusCode === 200) {
+        if (context.method === "patch" && response.statusCode === "200") {
           expect(
             specItem.content["application/vnd.api+json"]?.schema?.properties,
             `expected ${responseName} to have a schema`,
@@ -113,7 +114,7 @@ export const rules = {
         // Empty patch 204 content
         if (
           ["delete", "patch"].includes(context.method) &&
-          response.statusCode === 204
+          response.statusCode === "204"
         ) {
           expect(
             specItem.content,
@@ -122,7 +123,7 @@ export const rules = {
         }
 
         // Non-204 status codes must have content
-        if (response.statusCode !== 204) {
+        if (response.statusCode !== "204") {
           expect(specItem.content, `expected ${responseName} to have content`)
             .to.not.exist;
         }
@@ -130,7 +131,7 @@ export const rules = {
         // JSON:API data property
         if (
           ["get", "post"].includes(context.method) &&
-          [200, 201].includes(response.statusCode)
+          ["200", "201"].includes(response.statusCode)
         ) {
           expect(
             specItem.content["application/vnd.api+json"]?.schema?.properties
@@ -142,7 +143,7 @@ export const rules = {
         // JSON:API jsonapi property
         if (
           !["patch", "delete"].includes(context.method) &&
-          [200, 201].includes(response.statusCode)
+          ["200", "201"].includes(response.statusCode)
         ) {
           expect(
             specItem.content["application/vnd.api+json"]?.schema?.properties
@@ -152,7 +153,7 @@ export const rules = {
         }
 
         // Success post responses
-        if (context.method === "post" && response.statusCode === 201) {
+        if (context.method === "post" && response.statusCode === "201") {
           // Location header
           expect(
             specItem.headers,
@@ -178,8 +179,8 @@ export const rules = {
         // Top-level self links
         if (
           (["get", "patch"].includes(context.method) &&
-            response.statusCode === 200) ||
-          (context.method === "post" && response.statusCode === 201)
+            response.statusCode === "200") ||
+          (context.method === "post" && response.statusCode === "201")
         ) {
           expect(
             specItem.content["application/vnd.api+json"]?.schema?.properties
@@ -253,7 +254,7 @@ export const rules = {
       (response, context, docs, specItem) => {
         docs.includeDocsLink(links.jsonApi.compoundDocuments);
         if (isOpenApiPath(context.path)) return;
-        if ([200, 201].includes(response.statusCode)) {
+        if (["200", "201"].includes(response.statusCode)) {
           expect(
             specItem.content["application/vnd.api+json"]?.schema?.properties
               ?.included,
@@ -277,7 +278,7 @@ export const rules = {
         // Response data
         if (
           ["get", "post"].includes(context.method) &&
-          [200, 201].includes(response.statusCode)
+          ["200", "201"].includes(response.statusCode)
         ) {
           const responseSchema =
             specItem.content?.["application/vnd.api+json"]?.schema;
@@ -293,7 +294,7 @@ export const rules = {
         }
 
         // Patch response data
-        if (context.method === "patch" && response.statusCode === 200) {
+        if (context.method === "patch" && response.statusCode === "200") {
           const responseSchema =
             specItem.content?.["application/vnd.api+json"]?.schema;
           const schema: any = loadSchemaFromFile("patch-response-data.yaml");
@@ -308,7 +309,7 @@ export const rules = {
         }
 
         // Delete response data
-        if (context.method === "delete" && response.statusCode === 200) {
+        if (context.method === "delete" && response.statusCode === "200") {
           const responseSchema =
             specItem.content?.["application/vnd.api+json"]?.schema;
           const schema: any = loadSchemaFromFile("delete-response-data.yaml");

--- a/src/rulesets/tests/__snapshots__/end-end.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/end-end.test.ts.snap
@@ -38862,7 +38862,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },

--- a/src/rulesets/tests/__snapshots__/headers.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/headers.test.ts.snap
@@ -810,7 +810,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },
@@ -877,7 +877,7 @@ Object {
     Object {
       "added": Object {
         "description": "",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -1020,7 +1020,7 @@ Object {
     Object {
       "added": Object {
         "description": "",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -1294,7 +1294,7 @@ Object {
     Object {
       "added": Object {
         "description": "With headers",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -1366,7 +1366,7 @@ Object {
         },
         "value": Object {
           "description": "With headers",
-          "statusCode": 200,
+          "statusCode": "200",
         },
       },
       "condition": "have all headers",
@@ -1401,7 +1401,7 @@ Object {
     Object {
       "added": Object {
         "description": "No headers",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -1465,7 +1465,7 @@ Object {
         },
         "value": Object {
           "description": "No headers",
-          "statusCode": 200,
+          "statusCode": "200",
         },
       },
       "condition": "have all headers",

--- a/src/rulesets/tests/__snapshots__/lifecycle.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/lifecycle.test.ts.snap
@@ -810,7 +810,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },

--- a/src/rulesets/tests/__snapshots__/operations.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/operations.test.ts.snap
@@ -810,7 +810,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },
@@ -2207,7 +2207,7 @@ Object {
       "removed": Object {
         "before": Object {
           "description": "Example response",
-          "statusCode": 200,
+          "statusCode": "200",
         },
       },
     },
@@ -2256,7 +2256,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "Example response",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },

--- a/src/rulesets/tests/__snapshots__/properties.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/properties.test.ts.snap
@@ -445,7 +445,7 @@ Object {
     Object {
       "added": Object {
         "description": "",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -674,7 +674,7 @@ Object {
     Object {
       "added": Object {
         "description": "",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -917,7 +917,7 @@ Object {
     Object {
       "added": Object {
         "description": "",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -1107,7 +1107,7 @@ Object {
     Object {
       "added": Object {
         "description": "",
-        "statusCode": 200,
+        "statusCode": "200",
       },
       "changeType": "added",
       "location": Object {
@@ -2020,7 +2020,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },

--- a/src/rulesets/tests/__snapshots__/specification.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/specification.test.ts.snap
@@ -810,7 +810,7 @@ Object {
         "removed": Object {
           "before": Object {
             "description": "",
-            "statusCode": 200,
+            "statusCode": "200",
           },
         },
       },

--- a/src/rulesets/tests/fixtures.ts
+++ b/src/rulesets/tests/fixtures.ts
@@ -1,6 +1,6 @@
 import { SnykApiCheckDsl, SynkApiCheckContext } from "../../dsl";
 import { ApiCheckService, createTestDslFixture } from "@useoptic/api-checks";
-import { OpenAPIV3 } from "@useoptic/openapi-utilities";
+import { OpenAPIV3, factsToChangelog } from "@useoptic/openapi-utilities";
 import path from "path";
 export async function rulesFixture(
   before: OpenAPIV3.Document,
@@ -18,7 +18,15 @@ export async function rulesFixture(
       input.context,
     );
   }, rules);
-  const results = await checker.runRules(before, after, context);
+  const { currentFacts, nextFacts } = checker.generateFacts(before, after);
+  const results = await checker.runRulesWithFacts({
+    context,
+    nextFacts,
+    currentFacts,
+    changelog: factsToChangelog(currentFacts, nextFacts),
+    nextJsonLike: after,
+    currentJsonLike: before,
+  });
   return results;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "downlevelIteration": true
   },
   "include": [
     "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,18 +1725,18 @@
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@useoptic/api-checks@0.22.4":
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.22.4.tgz#679f67e1ae30772c413d7d40a76d182b85e9bfa5"
-  integrity sha512-NOyDQlJzGoS1wWBKKXEmJ7ibjf83SMKWeHicX8WJqLNCV6BeAaDOD7EMFNaNNPRK8XPcctTA6h3QWPSnbAjonw==
+"@useoptic/api-checks@0.22.5":
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.22.5.tgz#07d743a4a04a4a051a140753017f6044d51ff7f8"
+  integrity sha512-GlLtlNfcwnT4CV188d4nTk4/kW298LTWGdpXglJ8B3AIFhwf+CE5B2SDiVOijpGY4Qng6cHoc1UQNWeUJiYsnQ==
   dependencies:
     "@octokit/rest" "^18.12.0"
     "@sentry/node" "^6.15.0"
     "@stoplight/spectral-core" "^1.8.1"
     "@stoplight/spectral-rulesets" "^1.3.2"
-    "@useoptic/json-pointer-helpers" "0.22.4"
-    "@useoptic/openapi-io" "0.22.4"
-    "@useoptic/openapi-utilities" "0.22.4"
+    "@useoptic/json-pointer-helpers" "0.22.5"
+    "@useoptic/openapi-io" "0.22.5"
+    "@useoptic/openapi-utilities" "0.22.5"
     analytics-node "^6.0.0"
     chai "^4.3.4"
     commander "^8.3.0"
@@ -1756,22 +1756,22 @@
     ts-invariant "^0.9.4"
     uuid "^8.3.2"
 
-"@useoptic/json-pointer-helpers@0.22.4":
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.22.4.tgz#9538a129d72f08b6b1ea9c5be34bcd56a3fd1081"
-  integrity sha512-Xl32+cNTQ995NSfgolBPOzs7862BlzGpI6V3Yx3zns9yGLV0kne2zaAvtEsTudY91iS1pu5q0LRLcpuDtsa5Lg==
+"@useoptic/json-pointer-helpers@0.22.5":
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.22.5.tgz#dce3117139447db6b1dad9070da05c4f7dfc72a1"
+  integrity sha512-cfFaXZk8wRKqokZ0ugY4yMfcIfZlS/sHAqaiIzwKqWvE4PGIkEP620nTkaO/lWp4B+maS3K13AaL+rclv5CjKQ==
   dependencies:
     jsonpointer "^5.0.0"
 
-"@useoptic/openapi-io@0.22.4":
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.22.4.tgz#f6c0d68559bf56946587983925e42bd8b5043406"
-  integrity sha512-6istOLXLZ7D3mAVW4y4StS8XNICcSo7dII5OLCI08/YhfkK41Yai7LATNlSKoY4qiIxmUsu0cdTu3KoTzfeipQ==
+"@useoptic/openapi-io@0.22.5":
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.22.5.tgz#f4676645debc78e27e7d5e541cb871eb75d1a216"
+  integrity sha512-7C8hj+UwsN59t0IrrizAbEGbF5+k82TGfqPePDL4PivQlLOACLKiohXja0q3OYXT5QICWEGUJ6xuzYeywL7oOQ==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@jsdevtools/ono" "^7.1.3"
-    "@useoptic/json-pointer-helpers" "0.22.4"
-    "@useoptic/openapi-utilities" "0.22.4"
+    "@useoptic/json-pointer-helpers" "0.22.5"
+    "@useoptic/openapi-utilities" "0.22.5"
     copyfiles "^2.4.1"
     crypto-js "^4.1.1"
     fast-deep-equal "^3.1.3"
@@ -1785,12 +1785,12 @@
     ts-invariant "^0.9.3"
     yaml-ast-parser "^0.0.43"
 
-"@useoptic/openapi-utilities@0.22.4":
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.22.4.tgz#2247d4c0a211a7659319069290fc59d2e6c4acf5"
-  integrity sha512-Wtk1wD1dnxui35RswWh+qRLAz8NAtXHrqZktkEoz43zrSK2jL6Io2xhQuDqgE8XyG1/SOFuyhDmkg5oxHmremw==
+"@useoptic/openapi-utilities@0.22.5":
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.22.5.tgz#fe57cdf5f772392fda53caf0397275ff500f61d8"
+  integrity sha512-67p5kcdHng85HBUxq2ObU/2PaqsSGiGuP6Km5noGylI/B1FLihVnquPvagTBRXekXAh81BXwo/QPAc7OvLV/RA==
   dependencies:
-    "@useoptic/json-pointer-helpers" "0.22.4"
+    "@useoptic/json-pointer-helpers" "0.22.5"
     fast-deep-equal "^3.1.3"
     js-yaml "^4.1.0"
     lodash.sortby "^4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,21 +1725,22 @@
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@useoptic/api-checks@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.21.3.tgz#f19a2428b625c4bf4dfd3c4d71e045de8f328443"
-  integrity sha512-5tnOCT9WYVWocV2OkV+LXd3RELit+NYiVZ3+BVj3S/tUyrJXVZJyC3xZU1cmF/K92TUebw4TM3ok40pPdP6vug==
+"@useoptic/api-checks@0.22.4":
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.22.4.tgz#679f67e1ae30772c413d7d40a76d182b85e9bfa5"
+  integrity sha512-NOyDQlJzGoS1wWBKKXEmJ7ibjf83SMKWeHicX8WJqLNCV6BeAaDOD7EMFNaNNPRK8XPcctTA6h3QWPSnbAjonw==
   dependencies:
     "@octokit/rest" "^18.12.0"
     "@sentry/node" "^6.15.0"
     "@stoplight/spectral-core" "^1.8.1"
     "@stoplight/spectral-rulesets" "^1.3.2"
-    "@useoptic/json-pointer-helpers" "0.21.3"
-    "@useoptic/openapi-io" "0.21.3"
-    "@useoptic/openapi-utilities" "0.21.3"
+    "@useoptic/json-pointer-helpers" "0.22.4"
+    "@useoptic/openapi-io" "0.22.4"
+    "@useoptic/openapi-utilities" "0.22.4"
     analytics-node "^6.0.0"
     chai "^4.3.4"
     commander "^8.3.0"
+    follow-redirects "1.14.7"
     fs-extra "^10.0.0"
     ink "^3.2.0"
     ink-link "^2.0.0"
@@ -1749,48 +1750,47 @@
     lodash.groupby "^4.6.0"
     lodash.isequal "^4.5.0"
     nice-try "^3.0.0"
-    node-fetch "^2"
+    node-fetch "^2.6.7"
     react "^17.0.2"
     react-use "^17.3.1"
     ts-invariant "^0.9.4"
     uuid "^8.3.2"
 
-"@useoptic/json-pointer-helpers@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.21.3.tgz#e934d6af18906d39dcb1fbe1abae0f0c469a9f5d"
-  integrity sha512-/EXjzsenAERraUnNGtrbFfD/f8QcS7i6TDkwT4ViPG5n9BMpb/sPo0hQr2uX3aTXSAjDjYCi2u3VmLJga63mFw==
+"@useoptic/json-pointer-helpers@0.22.4":
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.22.4.tgz#9538a129d72f08b6b1ea9c5be34bcd56a3fd1081"
+  integrity sha512-Xl32+cNTQ995NSfgolBPOzs7862BlzGpI6V3Yx3zns9yGLV0kne2zaAvtEsTudY91iS1pu5q0LRLcpuDtsa5Lg==
   dependencies:
-    json-pointer "^0.6.1"
+    jsonpointer "^5.0.0"
 
-"@useoptic/openapi-io@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.21.3.tgz#1550e58f1fe43ee26083fd14423c0b59acb001b7"
-  integrity sha512-6PX9pzRNFIZeFaUUj3H0O2PAAYu8HgjTj4zbaTHF4kGnNpENVYCGWS5CN1rmtGzlD6/tmhtR04Hhqpil+P8EvA==
+"@useoptic/openapi-io@0.22.4":
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.22.4.tgz#f6c0d68559bf56946587983925e42bd8b5043406"
+  integrity sha512-6istOLXLZ7D3mAVW4y4StS8XNICcSo7dII5OLCI08/YhfkK41Yai7LATNlSKoY4qiIxmUsu0cdTu3KoTzfeipQ==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@jsdevtools/ono" "^7.1.3"
-    "@useoptic/json-pointer-helpers" "0.21.3"
-    "@useoptic/openapi-utilities" "0.21.3"
+    "@useoptic/json-pointer-helpers" "0.22.4"
+    "@useoptic/openapi-utilities" "0.22.4"
     copyfiles "^2.4.1"
     crypto-js "^4.1.1"
     fast-deep-equal "^3.1.3"
     fast-json-patch "^3.1.0"
     fs-extra "^10.0.0"
     js-yaml "^4.1.0"
-    json-pointer "^0.6.1"
     json-stable-stringify "^1.0.1"
     lodash.sortby "^4.7.0"
-    node-fetch "2.6.5"
+    node-fetch "^2.6.7"
     prettier "2.5.0"
     ts-invariant "^0.9.3"
     yaml-ast-parser "^0.0.43"
 
-"@useoptic/openapi-utilities@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.21.3.tgz#c18bd06419752ad7bf359a9577d89095e920262d"
-  integrity sha512-qwEJ0uW5xgZrpOdUSMrIoo9hk+ek8H40VA3CdhVyx3Cb5/qxq79pgjOwHyWQhMjafo1Sk8j1VksU5FZxQ+kUaQ==
+"@useoptic/openapi-utilities@0.22.4":
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.22.4.tgz#2247d4c0a211a7659319069290fc59d2e6c4acf5"
+  integrity sha512-Wtk1wD1dnxui35RswWh+qRLAz8NAtXHrqZktkEoz43zrSK2jL6Io2xhQuDqgE8XyG1/SOFuyhDmkg5oxHmremw==
   dependencies:
-    "@useoptic/json-pointer-helpers" "0.21.3"
+    "@useoptic/json-pointer-helpers" "0.22.4"
     fast-deep-equal "^3.1.3"
     js-yaml "^4.1.0"
     lodash.sortby "^4.7.0"
@@ -3068,7 +3068,7 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-follow-redirects@^1.14.0:
+follow-redirects@1.14.7, follow-redirects@^1.14.0:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
@@ -3077,11 +3077,6 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
-
-foreach@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -4202,13 +4197,6 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json-pointer@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.1.tgz#3c6caa6ac139e2599f5a1659d39852154015054d"
-  integrity sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==
-  dependencies:
-    foreach "^2.0.4"
-
 json-schema-traverse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
@@ -4622,17 +4610,17 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
-  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Updated optic-ci to `0.22.5`

There's a couple of changes here, the ones i want to call out are:
- statusCode is now returned as a string (openAPI has valid statusCodes of `4xx` or `default`) - our traverser didn't handle this previously. This should only affect rule definitions, and I believe all the snapshot tests that are updated should cover this?
- As part of the changelog entry point, there'll be a link to a survey to gather user feedback
- Some changes to the traverser interface - these are mainly internal facing changes, but some of these appear to be used in this repo (we're refining what our public interface needs to be, and once we have something stable we'll move to that)

Let me know if you have any questions!