### PR TITLE
fix: docker image errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,16 @@ COPY . .
 RUN yarn build
 
 FROM node:14-alpine AS clean-env
-COPY --from=build-env /sweater-comb/build /sweater-comb
+COPY --from=build-env /sweater-comb/build/ /sweater-comb/
+COPY --from=build-env /sweater-comb/babel.config.js /sweater-comb/
 COPY --from=build-env /sweater-comb/package*.json /sweater-comb/
 WORKDIR /sweater-comb
 RUN yarn install --production
 
-FROM gcr.io/distroless/nodejs:14
+FROM node:14-alpine
 ENV NODE_ENV production
-COPY --from=clean-env /sweater-comb /sweater-comb
+COPY --from=clean-env /sweater-comb/ /sweater-comb/
+COPY --from=build-env /sweater-comb/schemas/ /schemas/
 WORKDIR /sweater-comb
 USER 1000
-ENTRYPOINT ["/nodejs/bin/node", "index.js"]
+ENTRYPOINT ["/usr/local/bin/node", "index.js"]

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
+    "@babel/runtime": "^7.17.2",
     "@useoptic/api-checks": "0.22.7",
     "@useoptic/json-pointer-helpers": "0.22.7",
     "@useoptic/openapi-io": "0.22.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,6 +898,13 @@
     "@babel/helper-validator-option" "^7.14.5"
     "@babel/plugin-transform-typescript" "^7.16.0"
 
+"@babel/runtime@^7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"


### PR DESCRIPTION
Docker image builds > 1.2.0 do not work at all, they fail to execute
optic-ci. Example:

```
$ docker run --rm snyk/sweater-comb:1.2.2 --help
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
Require stack:
- /sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/commands/compare/compare.js
- /sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/commands/compare/index.js
- /sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/make-cli.js
- /sweater-comb/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
    at Object.<anonymous> (/sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/commands/compare/compare.js:3:30)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/commands/compare/compare.js',
    '/sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/commands/compare/index.js',
    '/sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/make-cli.js',
    '/sweater-comb/index.js'
  ]
}
```

Adding babel.config.js and the babel runtime as a package dependency
seems to fix this issue.

Also added schemas to the image build -- similar issue was fixed in the
package.json
[here](https://github.com/snyk/sweater-comb/pull/176/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R12),
but also needed in the image build as well, since we're
stripping it down.