### PR TITLE
feat: allow untenanted `/current_user` route

### DIFF
--- a/src/rulesets/operations.ts
+++ b/src/rulesets/operations.ts
@@ -166,7 +166,8 @@ export const rules = {
             url.startsWith("/orgs/{org_id}") ||
             url.startsWith("/groups/{group_id}") ||
             url === "/orgs" ||
-            url === "/groups"
+            url === "/groups" ||
+            url === "/current_user"
           )
         ) {
           expect.fail(`expected support for org or group tenant in ${url}`);

--- a/src/rulesets/tests/__snapshots__/operations.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/operations.test.ts.snap
@@ -3485,6 +3485,167 @@ Object {
 }
 `;
 
+exports[`orgOrGroupTenant path '/current_user' is valid: true 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "OpenAPI",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {},
+  },
+  "changelog": Array [
+    Object {
+      "added": Object {
+        "method": "get",
+        "pathPattern": "/current_user",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/current_user",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/current_user",
+          "get",
+        ],
+        "jsonPath": "/paths/~1current_user/get",
+        "kind": "operation",
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "OpenAPI",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/current_user": Object {
+        "get": Object {
+          "responses": Object {},
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "added": Object {
+          "method": "get",
+          "pathPattern": "/current_user",
+        },
+        "changeType": "added",
+        "location": Object {
+          "conceptualLocation": Object {
+            "method": "get",
+            "path": "/current_user",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/current_user",
+            "get",
+          ],
+          "jsonPath": "/paths/~1current_user/get",
+          "kind": "operation",
+        },
+      },
+      "condition": "have an org or group tenant",
+      "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+      "effectiveOnDate": undefined,
+      "isMust": true,
+      "isShould": false,
+      "passed": true,
+      "where": "added operation: GET /current_user",
+    },
+  ],
+}
+`;
+
+exports[`orgOrGroupTenant path '/current_user/thing' is valid: false 1`] = `
+Object {
+  "base": Object {
+    "info": Object {
+      "title": "OpenAPI",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {},
+  },
+  "changelog": Array [
+    Object {
+      "added": Object {
+        "method": "get",
+        "pathPattern": "/current_user/thing",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/current_user/thing",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/current_user/thing",
+          "get",
+        ],
+        "jsonPath": "/paths/~1current_user~1thing/get",
+        "kind": "operation",
+      },
+    },
+  ],
+  "next": Object {
+    "info": Object {
+      "title": "OpenAPI",
+      "version": "0.0.0",
+    },
+    "openapi": "3.0.1",
+    "paths": Object {
+      "/current_user/thing": Object {
+        "get": Object {
+          "responses": Object {},
+        },
+      },
+    },
+  },
+  "results": Array [
+    Object {
+      "change": Object {
+        "added": Object {
+          "method": "get",
+          "pathPattern": "/current_user/thing",
+        },
+        "changeType": "added",
+        "location": Object {
+          "conceptualLocation": Object {
+            "method": "get",
+            "path": "/current_user/thing",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/current_user/thing",
+            "get",
+          ],
+          "jsonPath": "/paths/~1current_user~1thing/get",
+          "kind": "operation",
+        },
+      },
+      "condition": "have an org or group tenant",
+      "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+      "effectiveOnDate": undefined,
+      "error": "expected support for org or group tenant in /current_user/thing",
+      "isMust": true,
+      "isShould": false,
+      "passed": false,
+      "where": "added operation: GET /current_user/thing",
+    },
+  ],
+}
+`;
+
 exports[`orgOrGroupTenant path '/group/{group_id}' is valid: false 1`] = `
 Object {
   "base": Object {

--- a/src/rulesets/tests/operations.test.ts
+++ b/src/rulesets/tests/operations.test.ts
@@ -158,6 +158,8 @@ describe("orgOrGroupTenant", () => {
     ${true}  | ${"/groups"}
     ${false} | ${"/groups/thing"}
     ${true}  | ${"/groups/{group_id}/thing"}
+    ${true}  | ${"/current_user"}
+    ${false} | ${"/current_user/thing"}
   `(`path '$path' is valid: $valid`, async ({ valid, path }) => {
     const result = await compare(baseForSpecificationTests)
       .to((spec) => {


### PR DESCRIPTION
Allows us to provide a route which shows the details for an authenticated user.
This is the third untenanted route and, hopefully, last. After this point, it’s likely we’ll need to rethink the linting around tenancy as we move away from it being the standard.