### PR TITLE
feat: singleton resources

### DIFF
--- a/docs/jsonapi.md
+++ b/docs/jsonapi.md
@@ -160,6 +160,30 @@ The error ID should uniquely identify this occurance of the problem. A server-ge
     - `PATCH /things/:id` to modify one
     - `DELETE /things/:id` to remove one
 
+### Resource Aggregation
+
+#### Singleton
+
+The resource at .../resource is a single object, rather than a collection.
+
+.../resource/{id} paths are not allowed.
+
+Singletons do not have an ID specified. This breaks slightly with JSON API, intended.
+
+#### Collection
+
+These are "normal" resources that may be individually addressed at .../resource/{id} or as a collection at .../resource. 
+
+#### Bulk
+
+Bulk resources cannot be individually addressed by path. .../resource/{id} paths are not allowed.
+
+POST creates many, and may respond 204 (no content). POST `.data` must be an array.
+
+GET, PATCH, and DELETE all operate on collections.
+
+Self links are links to the bulk GET.
+
 ### Query parameters and JSON API
 
 JSON API is highly prescriptive with query parameters, though they are only SHOULD suggestions, not MUST requirements. In particular, it suggests:

--- a/end-end-tests/api-standards/resources/thing/2021-11-10/001-ok-add-singleton.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/001-ok-add-singleton.yaml
@@ -1,0 +1,369 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: v3
+  version: 3.0.0
+servers:
+  - url: https://api.snyk.io/v3
+    description: Public Snyk API
+tags:
+  - name: Thing
+    description: Short description of what Thing represents
+paths:
+  /orgs/{org_id}/thing_settings:
+    x-snyk-resource-aggregation: singleton
+    get:
+      summary: Get thing settings
+      description: Get thing settings
+      operationId: getThingSettings
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "../../../../../components/parameters/pagination.yaml#/parameters/StartingAfter" }
+        - { $ref: "../../../../../components/parameters/pagination.yaml#/parameters/EndingBefore" }
+        - { $ref: "../../../../../components/parameters/pagination.yaml#/parameters/Limit" }
+      responses:
+        "200":
+          description: Returns a list of thing instances
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingSettingsResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+  /orgs/{org_id}/thing:
+    post:
+      summary: Create a new thing
+      description: Create a new thing
+      operationId: createThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+      responses:
+        "201":
+          description: Created thing successfully
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+            location:
+              { $ref: "../../../../../components/headers/headers.yaml#/LocationHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "409": { $ref: "../../../../../components/responses/409.yaml#/409" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+    get:
+      summary: List instances of thing
+      description: List instances of thing
+      operationId: listThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "../../../../../components/parameters/pagination.yaml#/parameters/StartingAfter" }
+        - { $ref: "../../../../../components/parameters/pagination.yaml#/parameters/EndingBefore" }
+        - { $ref: "../../../../../components/parameters/pagination.yaml#/parameters/Limit" }
+      responses:
+        "200":
+          description: Returns a list of thing instances
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingCollectionResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+  /orgs/{org_id}/thing/{thing_id}:
+    get:
+      summary: Get an instance of thing
+      description: Get an instance of thing
+      operationId: getThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Returns an instance of thing
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+    patch:
+      summary: Update an instance of thing
+      description: Update an instance of thing
+      operationId: updateThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Instance of thing is updated.
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "../../../../../components/headers/headers.yaml#/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "../../../../../components/headers/headers.yaml#/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "204": { $ref: "../../../../../components/responses/204.yaml#/204" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "409": { $ref: "../../../../../components/responses/409.yaml#/409" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+    delete:
+      summary: Delete an instance of thing
+      description: Delete an instance of thing
+      operationId: deleteThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "204": { $ref: "../../../../../components/responses/204.yaml#/204" }
+        "400": { $ref: "../../../../../components/responses/400.yaml#/400" }
+        "401": { $ref: "../../../../../components/responses/401.yaml#/401" }
+        "403": { $ref: "../../../../../components/responses/403.yaml#/403" }
+        "404": { $ref: "../../../../../components/responses/404.yaml#/404" }
+        "409": { $ref: "../../../../../components/responses/409.yaml#/409" }
+        "500": { $ref: "../../../../../components/responses/500.yaml#/500" }
+components:
+  parameters:
+    OrgId:
+      name: org_id
+      in: path
+      required: true
+      description: Org ID
+      schema:
+        type: string
+        format: uuid
+    ThingId:
+      name: thing_id
+      in: path
+      required: true
+      description: Unique identifier for thing instances
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    ThingResourceResponse:
+      type: object
+      description: Response containing a single thing resource object
+      properties:
+        jsonapi: { $ref: "../../../../../components/common.yaml#/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingResource" }
+        links: { $ref: "../../../../../components/common.yaml#/SelfLink" }
+
+    ThingCollectionResponse:
+      type: object
+      description: Response containing a collection of thing resource objects
+      properties:
+        jsonapi: { $ref: "../../../../../components/common.yaml#/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingCollection" }
+        links: { $ref: "../../../../../components/common.yaml#/PaginatedLinks" }
+
+    ThingResource:
+      type: object
+      description: thing resource object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+        type: { $ref: "../../../../../components/types.yaml#/Types" }
+        attributes: { $ref: "#/components/schemas/ThingAttributes" }
+        relationships: { $ref: "#/components/schemas/ThingRelationships" }
+      additionalProperties: false
+
+    ThingRelationships:
+      type: object
+      properties:
+        example: { $ref: "../../../../../components/common.yaml#/Relationship" }
+      additionalProperties: false
+
+    ThingCollection:
+      type: array
+      items: { $ref: "#/components/schemas/ThingResource" }
+
+    ThingAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of this instance of thing.
+          example: thing
+        created:
+          type: string
+          description: Timestamp when this instance of thing was created.
+          format: date-time
+          example: "2021-10-05T13:23:17Z"
+        updated:
+          type: string
+          description: Timestamp when this instance of thing was last updated.
+          format: date-time
+          example: "2021-10-05T13:25:29Z"
+        description:
+          type: string
+          description: User-friendly description of this instance of thing.
+          example: "This is a thing named thing."
+      additionalProperties: false
+
+    ThingSettingsResponse:
+      type: object
+      description: Response containing the settings for thing resource objects
+      properties:
+        jsonapi: { $ref: "../../../../../components/common.yaml#/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingSettingsResource" }
+        links: { $ref: "../../../../../components/common.yaml#/PaginatedLinks" }
+    ThingSettingsResource:
+      type: object
+      description: thing settings resource object
+      properties:
+        type: { $ref: "../../../../../components/types.yaml#/Types" }
+        attributes: { $ref: "#/components/schemas/ThingSettingsAttributes" }
+      additionalProperties: false
+    ThingSettingsAttributes:
+      type: object
+      properties:
+        good:
+          type: boolean
+          description: new things are good
+          example: true
+        strange:
+          type: boolean
+          description: new things are strange
+          example: false
+      additionalProperties: false

--- a/end-end-tests/api-standards/test-bulk.bash
+++ b/end-end-tests/api-standards/test-bulk.bash
@@ -31,6 +31,8 @@ cat >$tempdir/passes <<EOF
         "from": "$HERE/resources/thing/2021-11-10/000-fail-naming.yaml", "to": "$HERE/resources/thing/2021-11-10/000-fail-naming.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }, {
         "from": "$HERE/resources/thing/2021-11-10/000-baseline-in-reform.yaml", "to": "$HERE/resources/thing/2021-11-10/002-fail-tenancy.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
+    }, {
+        "from": "$HERE/resources/thing/2021-11-10/000-baseline.yaml", "to": "$HERE/resources/thing/2021-11-10/001-ok-add-singleton.yaml", "context": {"changeDate": "2021-11-11", "changeResource": "thing", "changeVersion": {"date": "2021-11-10", "stability": "experimental"}}
     }]
 }
 EOF


### PR DESCRIPTION
This adds support for singleton resources, as described in #71.

Properties of singletons:

- Path item has an extension value, `x-snyk-resource-aggregation: singleton`
  - Other possible values might be: `standard` (for lack of a better
    word) and `bulk` (to address the case where we do not make
    single resources addressable.
- Singletons' `.data` schema type is `object`.
- Singletons do not allow /resource/{id}.
- Singletons do not specify an `.id` in the resource. Their type alone is
  their identity. This departs slightly from JSON API and that is
  intended.

Fixes #71