### PR TITLE
[Example] make sure all versions use the same shared components`$ref`

### DIFF
--- a/end-end-tests/api-standards/resources/thing/2021-11-10/000-baseline.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/000-baseline.yaml
@@ -9,6 +9,9 @@ servers:
 tags:
   - name: Thing
     description: Short description of what Thing represents
+x-v3-schemas:
+  $ref: https://raw.githubusercontent.com/snyk/sweater-comb/v1.5.0/components/parameters/version.yaml
+  #                                                         ^ tag 
 paths:
   /orgs/{org_id}/thing:
     post:
@@ -18,7 +21,7 @@ paths:
       tags:
         - Thing
       parameters:
-        - { $ref: "../../../../../components/parameters/version.yaml#/Version" }
+        - { $ref: '#/x-v3-schemas/Version' }
         - { $ref: '#/components/parameters/OrgId' }
       responses:
         "201":


### PR DESCRIPTION
_[Example Only] -- do not merge_

You all have shared that you plan to put shared schema on GitHub and let users consume them using `$ref` 

This has some challenges I think using JSON Schema Refs differently could solve. 
- Long URLs are hard to read
- If people are copy / pasting, they might end up with inconsistent versions ie one URL uses tag 1.4 and another URL uses tag 1.5
- It's difficult to update every $ref at once 

This is a really simple example where we import your shared schemas to an extension ie `x-v3-schemas` and then, everywhere else, resolve those via `#/x-v3-schemas/Target` 

Right now your shared schemas are still spread across multiple files. To make this work best, I'd suggest having one "entry point" that follows the standard components section OpenAPI conventions:
- parameters 
- schemas
- responses

https://swagger.io/docs/specification/components/

This probably just means adding a registry-like schema that `$ref` out to all the subcomponents you want in the shared schemas users import. 