### PR TITLE
feat: format for query params with ids

### DIFF
--- a/src/rulesets/operations.ts
+++ b/src/rulesets/operations.ts
@@ -194,6 +194,28 @@ export const rules = {
       },
     );
   },
+  queryParameterIdFormatting: ({ request }: SnykApiCheckDsl) => {
+    request.queryParameter.added.must(
+      "use UUID format for query params with _id suffix",
+      (queryParameter, context, docs) => {
+        // TODO
+        expect.fail(
+          `expected request query parameter ${queryParameter.name} to use format UUID`,
+        );
+      },
+    );
+
+    request.queryParameter.added.must(
+      "use _id suffix for UUID formatted query params",
+      (queryParameter, context, docs) => {
+        // TODO
+        expect.fail(
+          `expected request query parameter ${queryParameter.name} to have _id suffix`,
+        );
+      },
+    );
+  },
+
   preventAddingRequiredQueryParameters: ({ request }: SnykApiCheckDsl) => {
     request.queryParameter.added.must(
       "not be required",

--- a/src/rulesets/tests/operations.test.ts
+++ b/src/rulesets/tests/operations.test.ts
@@ -313,6 +313,46 @@ describe("operation parameters", () => {
       expect(result).toMatchSnapshot();
     });
 
+    describe.only("Id query parameter", () => {
+      it("fails when adding foo_id query parameter not formated as UUID", async () => {
+        const result = await compare(baseForOperationMetadataTests)
+          .to((spec) => {
+            spec.paths!["/example"]!.get!.parameters = [
+              {
+                in: "query",
+                name: "foo_id",
+              },
+            ];
+            return spec;
+          })
+          .withRule(rules.queryParameterIdFormatting, emptyContext);
+
+        expect(result.results[0].passed).toBeFalsy();
+        // expect(result).toMatchSnapshot();
+      });
+
+      it("fails when adding UUID formated query parameter not named with _id suffix", async () => {
+        const result = await compare(baseForOperationMetadataTests)
+          .to((spec) => {
+            spec.paths!["/example"]!.get!.parameters = [
+              {
+                in: "query",
+                name: "foo",
+                schema: {
+                  type: "string",
+                  format: "uuid",
+                },
+              },
+            ];
+            return spec;
+          })
+          .withRule(rules.queryParameterIdFormatting, emptyContext);
+
+        expect(result.results[0].passed).toBeFalsy();
+        // expect(result).toMatchSnapshot();
+      });
+    });
+
     it("fails when adding a required query parameter", async () => {
       // const base = JSON.parse(JSON.stringify(baseForOperationMetadataTests));
       // base.paths!["/example"]!.get!.parameters = [];


### PR DESCRIPTION
This change adds a linter rule to ensure query params with ids:

- Use UUID format for query params with `_id` suffix
- Use `_id` suffix for UUID formatted query params

eg: `/example?foo_id=f5d14962-7b36-44e9-972d-9a764a9c2a3f`

related: https://github.com/snyk/sweater-comb/issues/207