### PR TITLE
fix: lodash.isequal runtime error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,27 +31,6 @@ jobs:
           name: E2E Test
           command: ./end-end-tests/api-standards/test-bulk.bash
 
-  docker-release:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: '20.10.7'
-      - run:
-          name: Build and push Docker image
-          environment:
-            GIT_BRANCH: << pipeline.git.branch >>
-            GIT_TAG: << pipeline.git.tag >>
-          command: |-
-            [ -n "$IMAGE" ] || exit 1
-            export TAG=${GIT_TAG:-${GIT_BRANCH}}
-            [ -n "$TAG" ] || exit 1
-            # Authenticate to OCI image repository
-            echo "${GITHUB_TOKEN}" | docker login ghcr.io -u snyk --password-stdin
-            # Build and push the just-built image
-            set -x
-            ./scripts/release-docker.bash
-
   npm-release:
     <<: *defaults
     steps:
@@ -74,12 +53,3 @@ workflows:
           filters:
             branches:
               only: 'main'
-  docker_publish:
-    jobs:
-      - docker-release:
-          name: Docker Image Release
-          filters:
-            branches:
-              ignore: '/.*/'
-            tags:
-              only: '/^v.*$/'

--- a/package.json
+++ b/package.json
@@ -51,12 +51,14 @@
     "chai": "^4.3.4",
     "change-case": "^4.1.2",
     "fs-extra": "^10.0.0",
+    "lodash.isequal": "^4.5.0",
     "nice-try": "^3.0.0",
     "yargs": "^17.3.0"
   },
   "bundledDependencies": [
     "@useoptic/api-checks",
     "@useoptic/json-pointer-helpers",
+    "@useoptic/openapi-cli",
     "@useoptic/openapi-io",
     "@useoptic/openapi-utilities"
   ],


### PR DESCRIPTION
Execution of `sweater-comb compare` was failing on a runtime error:

```
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module 'lodash.isequal'
Require stack:
```

without this change.

Let the record show I am not a fan of bundled dependencies, but it's
necessary here due to the conflicts between ajv 6 and 8, both
dependencies of many common tools.