### PR TITLE
chore: set temporary baseline for commitlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "changelog": "yarn ts-node src/changelog.ts",
     "lint": "run-p lint:*",
     "lint:formatting": "prettier --check 'src/**/*.{js,ts}'",
-    "lint:commits": "commitlint --from=HEAD~1",
+    "lint:commits": "commitlint --from=ccbdd18876ab01a2be0801211a13a8609012425e -V",
     "format": "prettier --write 'src/**/*.{js,ts}'"
   },
   "devDependencies": {


### PR DESCRIPTION
Until we have enough clean recent history, we'll need to set a hard
commit baseline after which we expect all commits to be conventional.