### PR TITLE
fix: use updated public REST API endpoint

### DIFF
--- a/src/workflows/templates/new-resource-spec.ts
+++ b/src/workflows/templates/new-resource-spec.ts
@@ -54,7 +54,7 @@ function baseOpenApiSpec(
       "x-singular-name": name.toLowerCase(),
     },
     servers: [
-      { url: "https://api.snyk.io/v3", description: "Public Snyk API" },
+      { url: "https://api.snyk.io/rest", description: "Snyk REST API" },
     ],
     tags: [
       {

--- a/src/workflows/tests/templates.test.ts
+++ b/src/workflows/tests/templates.test.ts
@@ -38,6 +38,11 @@ function checkTemplate(template) {
     template(updatedSpec, {
       pluralResourceName: "users",
     });
+    expect(updatedSpec.servers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: "https://api.snyk.io/rest" }),
+      ]),
+    );
     const results = await check(baseSpec, updatedSpec);
     const failedChecks = results.filter((r) => !r.passed);
     expect(failedChecks.length).toBe(0);


### PR DESCRIPTION
We're just calling "v3" the REST API now; it's now a multiverse of
concurrent versions vervetted together.