### PR TITLE
chore: bump optic to 0.24.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
   "name": "@snyk/sweater-comb",
-  "packageManager": "yarn@3.0.2",
   "version": "1.0.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
-  "bin": {
-    "sweater-comb": "build/index.js"
-  },
+  "bin": "build/index.js",
   "files": [
     "/build",
     "/schemas"
@@ -43,11 +40,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
-    "@useoptic/api-checks": "0.24.0",
-    "@useoptic/json-pointer-helpers": "0.24.0",
-    "@useoptic/openapi-cli": "0.24.0",
-    "@useoptic/openapi-io": "0.24.0",
-    "@useoptic/openapi-utilities": "0.24.0",
+    "@useoptic/api-checks": "0.24.6",
+    "@useoptic/json-pointer-helpers": "0.24.6",
+    "@useoptic/openapi-cli": "0.24.6",
+    "@useoptic/openapi-io": "0.24.6",
+    "@useoptic/openapi-utilities": "0.24.6",
     "chai": "^4.3.4",
     "chalk": "^4.0.0",
     "change-case": "^4.1.2",

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,12 +1,8 @@
-import {
-  parseOpenAPIWithSourcemap,
-  sourcemapReader,
-} from "@useoptic/openapi-io";
+import { parseOpenAPIWithSourcemap } from "@useoptic/openapi-io";
 import type { JsonSchemaSourcemap } from "@useoptic/openapi-io";
 import {
   factsToChangelog,
   IChange,
-  OpenApiFact,
   OpenAPITraverser,
   OpenAPIV3,
 } from "@useoptic/openapi-utilities";
@@ -26,7 +22,7 @@ const parseOpenAPI = async (path: string): Promise<ParseOpenAPIResult> => {
 export async function changeLogBetween(
   from: OpenAPIV3.Document,
   to: OpenAPIV3.Document,
-): Promise<IChange<OpenApiFact>[]> {
+): Promise<IChange[]> {
   const currentTraverser = new OpenAPITraverser();
   currentTraverser.traverse(from);
   const currentFacts = [...currentTraverser.facts()];

--- a/src/rulesets/tests/__snapshots__/lifecycle.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/lifecycle.test.ts.snap
@@ -888,7 +888,35 @@ Object {
     },
     "x-snyk-api-stability": "ga",
   },
-  "changelog": Array [],
+  "changelog": Array [
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-snyk-api-stability": "beta",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-snyk-api-stability": "ga",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+  ],
   "next": Object {
     "info": Object {
       "title": "OpenAPI",
@@ -952,7 +980,34 @@ Object {
       },
     },
   },
-  "changelog": Array [],
+  "changelog": Array [
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-snyk-api-stability": "published",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+  ],
   "next": Object {
     "info": Object {
       "title": "OpenAPI",
@@ -1080,7 +1135,35 @@ Object {
     },
     "x-snyk-api-stability": "wip",
   },
-  "changelog": Array [],
+  "changelog": Array [
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-snyk-api-stability": "beta",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-snyk-api-stability": "wip",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+  ],
   "next": Object {
     "info": Object {
       "title": "OpenAPI",
@@ -1143,7 +1226,34 @@ Object {
       },
     },
   },
-  "changelog": Array [],
+  "changelog": Array [
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-optic-ci-empty-spec": true,
+        },
+        "before": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+  ],
   "next": Object {
     "info": Object {
       "title": "OpenAPI",
@@ -1211,7 +1321,34 @@ Object {
       },
     },
   },
-  "changelog": Array [],
+  "changelog": Array [
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-optic-ci-empty-spec": true,
+        },
+        "before": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+  ],
   "next": Object {
     "info": Object {
       "title": "OpenAPI",
@@ -1290,7 +1427,34 @@ Object {
       },
     },
   },
-  "changelog": Array [],
+  "changelog": Array [
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+          "x-optic-ci-empty-spec": true,
+        },
+        "before": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+  ],
   "next": Object {
     "info": Object {
       "title": "OpenAPI",

--- a/src/rulesets/tests/__snapshots__/operations.test.ts.snap
+++ b/src/rulesets/tests/__snapshots__/operations.test.ts.snap
@@ -1319,6 +1319,31 @@ Object {
         "kind": "operation",
       },
     },
+    Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "OpenAPI",
+            "version": "0.0.0",
+          },
+          "openapi": "3.0.1",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
   ],
   "next": Object {
     "info": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,19 +2079,19 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@useoptic/api-checks@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.24.0.tgz#376c2e0343469ff01eeaf63ce2a3c6001354effd"
-  integrity sha512-CtZU9oFp3dGpya/xCtJIHuDspR4APPTT0q5GFo+1lIaMHynIPrSDlr/e6pl+vDGJV/mxxrGWRZZdyH6NcgGOYA==
+"@useoptic/api-checks@0.24.6":
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.24.6.tgz#a980f3549b849a0e8e39c99a6d5ea2d0fd444ee0"
+  integrity sha512-AQ7UC7JRo96WEHXC2eyZ/78K5VRGBx+aIsxxkHu1dT6nLW5R6epueITdeVyoQlD+UxKHBAFh7lSI4OBsq/83hQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@octokit/rest" "^18.12.0"
     "@sentry/node" "^6.15.0"
     "@stoplight/spectral-core" "^1.8.1"
     "@stoplight/spectral-rulesets" "^1.3.2"
-    "@useoptic/json-pointer-helpers" "0.24.0"
-    "@useoptic/openapi-io" "0.24.0"
-    "@useoptic/openapi-utilities" "0.24.0"
+    "@useoptic/json-pointer-helpers" "0.24.6"
+    "@useoptic/openapi-io" "0.24.6"
+    "@useoptic/openapi-utilities" "0.24.6"
     analytics-node "^6.0.0"
     chai "^4.3.4"
     chalk "^4.1.2"
@@ -2108,21 +2108,21 @@
     ts-invariant "^0.9.4"
     uuid "^8.3.2"
 
-"@useoptic/json-pointer-helpers@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.24.0.tgz#985a1282f0f18a682e2656dbbbd360fd2a41595a"
-  integrity sha512-EPP6xaYIGf1AzqbWo2QxK0ZeneMIFueCBleORzQXfHouzfpnlJqutV9wkL3+Ku6odSqqbwrPflyXTASkvKzIAw==
+"@useoptic/json-pointer-helpers@0.24.6":
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.24.6.tgz#432d486425cdbe04b16dfb960f4c2571682676c7"
+  integrity sha512-lncEdz076hkga2S/XRvBf0xL8x5WvHq793o18aZ8Mh1MR46nClo0n6h4cqeY3YLebXUkiV0Rn2i6mqH1i36dfg==
   dependencies:
     jsonpointer "^5.0.0"
 
-"@useoptic/openapi-cli@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-cli/-/openapi-cli-0.24.0.tgz#c218ca6b741fa9acc551782bc1abcfc7476963fd"
-  integrity sha512-ARwyz4YJfiXbn8hEDSu6xJMpRZGsm54ZJeBcBZ2YwLrWHc0ruSSquKvqlbS/0iq5WL2CYc6MDclCNq7GEhG9Tg==
+"@useoptic/openapi-cli@0.24.6":
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-cli/-/openapi-cli-0.24.6.tgz#138648dad0161b525306d992a5e70f8aa37918e3"
+  integrity sha512-VJRYjk4C8Q3YD+wk8dp2Vh+aB7nsreafOFGRPVqXRuS6L3Z/uuSvXsLdNwZEd7lsd4g8JWllLyDDR0mP1XbM+g==
   dependencies:
-    "@useoptic/json-pointer-helpers" "0.24.0"
-    "@useoptic/openapi-io" "0.24.0"
-    "@useoptic/openapi-utilities" "0.24.0"
+    "@useoptic/json-pointer-helpers" "0.24.6"
+    "@useoptic/openapi-io" "0.24.6"
+    "@useoptic/openapi-utilities" "0.24.6"
     analytics-node "^6.0.0"
     axax "^0.2.2"
     commander "^9.0.0"
@@ -2130,16 +2130,17 @@
     is-url "^1.2.4"
     json-schema-traverse "^1.0.0"
     ts-invariant "^0.9.4"
+    ts-results "^3.3.0"
 
-"@useoptic/openapi-io@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.24.0.tgz#795b6d6eaaa0c62797403c38b84a57626b12681f"
-  integrity sha512-U93yKglKKqkAYxLkH1Aan2jz/9vN9nggPNBBqp/Irb0BdUIEt0WmSJuHHoCSGJyu0I4YVMkmJRI2TjApM5UEmQ==
+"@useoptic/openapi-io@0.24.6":
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.24.6.tgz#f4561d4267b7513b5c8115b2145a5ccfed6de6df"
+  integrity sha512-T/XmTCCoftDnxKBHn5Pv+Un1pW9kZ47P6aEFleRlWkMNt6L17z99UDIu5Rowwgpi/XB3KlPgRoLXheX496E0FA==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@jsdevtools/ono" "^7.1.3"
-    "@useoptic/json-pointer-helpers" "0.24.0"
-    "@useoptic/openapi-utilities" "0.24.0"
+    "@useoptic/json-pointer-helpers" "0.24.6"
+    "@useoptic/openapi-utilities" "0.24.6"
     copyfiles "^2.4.1"
     crypto-js "^4.1.1"
     fast-deep-equal "^3.1.3"
@@ -2153,12 +2154,12 @@
     ts-invariant "^0.9.3"
     yaml-ast-parser "^0.0.43"
 
-"@useoptic/openapi-utilities@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.24.0.tgz#7ddcdcd3fb6f04ad24fb5dc6a5bc7215cd362b49"
-  integrity sha512-KkuF3nVaEDCV+O+4mgRmhCJC+olw7cNfReP6leo88gOvXNat6rD8xUx12gB7MmnubI2uuZrs2wXXgC7txj6VAA==
+"@useoptic/openapi-utilities@0.24.6":
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.24.6.tgz#336201fa6ad24432fe7b1a118e74979a6f0b71cc"
+  integrity sha512-jNKVQL4sQZyumowj7E5HtNjeZPYPHVtJt8Kji5KBXqUHxwAplx+k5ki6mgnhVs/j4S5MglbBMUEMQeKdG81/kg==
   dependencies:
-    "@useoptic/json-pointer-helpers" "0.24.0"
+    "@useoptic/json-pointer-helpers" "0.24.6"
     fast-deep-equal "^3.1.3"
     js-yaml "^4.1.0"
     lodash.sortby "^4.7.0"
@@ -6334,6 +6335,11 @@ ts-node@^10.4.0:
     diff "^4.0.1"
     make-error "^1.1.1"
     yn "3.1.1"
+
+ts-results@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ts-results/-/ts-results-3.3.0.tgz#68623a6c18e65556287222dab76498a28154922f"
+  integrity sha512-FWqxGX2NHp5oCyaMd96o2y2uMQmSu8Dey6kvyuFdRJ2AzfmWo3kWa4UsPlCGlfQ/qu03m09ZZtppMoY8EMHuiA==
 
 tslib@^1.14.1, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
PR bumps optic from `0.24.0` -> `0.24.6`. 

Downstream changes are:
- Specification facts are now emitted (the metadata on the spec like `info` or `servers`) - this means the changelog will now render metadata changes as well (there's some follow up work to render rule failures on these nodes given how some of the rules around lifecycles are written as well, as well as some rendering improvements we'll be making following this).
- Changed some internal typings for better typescript inferences (`IFact` and `IChange`)