### PR TITLE
chore: demonstrate array items missing issue

### DIFF
--- a/end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-invalid-items.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-invalid-items.yaml
@@ -1,0 +1,296 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: v3
+  version: 3.0.0
+servers:
+  - url: https://api.snyk.io/v3
+    description: Public Snyk API
+tags:
+  - name: Thing
+    description: Short description of what Thing represents
+paths:
+  /orgs/{org_id}/thing:
+    post:
+      summary: Create a new thing
+      description: Create a new thing
+      operationId: createThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+      responses:
+        "201":
+          description: Created thing successfully
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+            location:
+              { $ref: "#/components/x-rest-common/headers/LocationHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "409": { $ref: "#/components/x-rest-common/responses/409" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+    get:
+      summary: List instances of thing
+      description: List instances of thing
+      operationId: listThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/x-rest-common/parameters/StartingAfter" }
+        - { $ref: "#/components/x-rest-common/parameters/EndingBefore" }
+        - { $ref: "#/components/x-rest-common/parameters/Limit" }
+      responses:
+        "200":
+          description: Returns a list of thing instances
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingCollectionResponse" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+  /orgs/{org_id}/thing/{thing_id}:
+    get:
+      summary: Get an instance of thing
+      description: Get an instance of thing
+      operationId: getThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Returns an instance of thing
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+    patch:
+      summary: Update an instance of thing
+      description: Update an instance of thing
+      operationId: updateThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Instance of thing is updated.
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "204": { $ref: "#/components/x-rest-common/responses/204" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "409": { $ref: "#/components/x-rest-common/responses/409" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+    delete:
+      summary: Delete an instance of thing
+      description: Delete an instance of thing
+      operationId: deleteThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "204": { $ref: "#/components/x-rest-common/responses/204" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "409": { $ref: "#/components/x-rest-common/responses/409" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+components:
+  x-rest-common:
+    $ref: '../../../../../components/common.yaml'
+  parameters:
+    OrgId:
+      name: org_id
+      in: path
+      required: true
+      description: Org ID
+      schema:
+        type: string
+        format: uuid
+    ThingId:
+      name: thing_id
+      in: path
+      required: true
+      description: Unique identifier for thing instances
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    ThingResourceResponse:
+      type: object
+      description: Response containing a single thing resource object
+      properties:
+        jsonapi: { $ref: "#/components/x-rest-common/schemas/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingResource" }
+        links: { $ref: "#/components/x-rest-common/schemas/SelfLink" }
+
+    ThingCollectionResponse:
+      type: object
+      description: Response containing a collection of thing resource objects
+      properties:
+        jsonapi: { $ref: "#/components/x-rest-common/schemas/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingCollection" }
+        links: { $ref: "#/components/x-rest-common/schemas/PaginatedLinks" }
+
+    ThingResource:
+      type: object
+      description: thing resource object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+        type: { $ref: "#/components/x-rest-common/schemas/Types" }
+        attributes: { $ref: "#/components/schemas/ThingAttributes" }
+        relationships: { $ref: "#/components/schemas/ThingRelationships" }
+      additionalProperties: false
+
+    ThingRelationships:
+      type: object
+      properties:
+        example: { $ref: "#/components/x-rest-common/schemas/Relationship" }
+      additionalProperties: false
+
+    ThingCollection:
+      type: array
+      items: no
+
+    ThingAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of this instance of thing.
+          example: thing
+        created:
+          type: string
+          description: Timestamp when this instance of thing was created.
+          format: date-time
+          example: "2021-10-05T13:23:17Z"
+        updated:
+          type: string
+          description: Timestamp when this instance of thing was last updated.
+          format: date-time
+          example: "2021-10-05T13:25:29Z"
+        description:
+          type: string
+          description: User-friendly description of this instance of thing.
+          example: "This is a thing named thing."
+      additionalProperties: false

--- a/end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-missing-items.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-missing-items.yaml
@@ -1,0 +1,295 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: v3
+  version: 3.0.0
+servers:
+  - url: https://api.snyk.io/v3
+    description: Public Snyk API
+tags:
+  - name: Thing
+    description: Short description of what Thing represents
+paths:
+  /orgs/{org_id}/thing:
+    post:
+      summary: Create a new thing
+      description: Create a new thing
+      operationId: createThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+      responses:
+        "201":
+          description: Created thing successfully
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+            location:
+              { $ref: "#/components/x-rest-common/headers/LocationHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "409": { $ref: "#/components/x-rest-common/responses/409" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+    get:
+      summary: List instances of thing
+      description: List instances of thing
+      operationId: listThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/x-rest-common/parameters/StartingAfter" }
+        - { $ref: "#/components/x-rest-common/parameters/EndingBefore" }
+        - { $ref: "#/components/x-rest-common/parameters/Limit" }
+      responses:
+        "200":
+          description: Returns a list of thing instances
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingCollectionResponse" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+  /orgs/{org_id}/thing/{thing_id}:
+    get:
+      summary: Get an instance of thing
+      description: Get an instance of thing
+      operationId: getThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Returns an instance of thing
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+    patch:
+      summary: Update an instance of thing
+      description: Update an instance of thing
+      operationId: updateThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "200":
+          description: Instance of thing is updated.
+          headers:
+            snyk-version-requested:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionRequestedResponseHeader",
+              }
+            snyk-version-served:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionServedResponseHeader",
+              }
+            snyk-request-id:
+              {
+                $ref: "#/components/x-rest-common/headers/RequestIdResponseHeader",
+              }
+            snyk-version-lifecycle-stage:
+              {
+                $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
+              }
+            deprecation:
+              {
+                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
+              }
+            sunset:
+              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: "#/components/schemas/ThingResourceResponse" }
+        "204": { $ref: "#/components/x-rest-common/responses/204" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "409": { $ref: "#/components/x-rest-common/responses/409" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+    delete:
+      summary: Delete an instance of thing
+      description: Delete an instance of thing
+      operationId: deleteThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: "#/components/x-rest-common/parameters/Version" }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/ThingId" }
+      responses:
+        "204": { $ref: "#/components/x-rest-common/responses/204" }
+        "400": { $ref: "#/components/x-rest-common/responses/400" }
+        "401": { $ref: "#/components/x-rest-common/responses/401" }
+        "403": { $ref: "#/components/x-rest-common/responses/403" }
+        "404": { $ref: "#/components/x-rest-common/responses/404" }
+        "409": { $ref: "#/components/x-rest-common/responses/409" }
+        "500": { $ref: "#/components/x-rest-common/responses/500" }
+components:
+  x-rest-common:
+    $ref: '../../../../../components/common.yaml'
+  parameters:
+    OrgId:
+      name: org_id
+      in: path
+      required: true
+      description: Org ID
+      schema:
+        type: string
+        format: uuid
+    ThingId:
+      name: thing_id
+      in: path
+      required: true
+      description: Unique identifier for thing instances
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    ThingResourceResponse:
+      type: object
+      description: Response containing a single thing resource object
+      properties:
+        jsonapi: { $ref: "#/components/x-rest-common/schemas/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingResource" }
+        links: { $ref: "#/components/x-rest-common/schemas/SelfLink" }
+
+    ThingCollectionResponse:
+      type: object
+      description: Response containing a collection of thing resource objects
+      properties:
+        jsonapi: { $ref: "#/components/x-rest-common/schemas/JsonApi" }
+        data: { $ref: "#/components/schemas/ThingCollection" }
+        links: { $ref: "#/components/x-rest-common/schemas/PaginatedLinks" }
+
+    ThingResource:
+      type: object
+      description: thing resource object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+        type: { $ref: "#/components/x-rest-common/schemas/Types" }
+        attributes: { $ref: "#/components/schemas/ThingAttributes" }
+        relationships: { $ref: "#/components/schemas/ThingRelationships" }
+      additionalProperties: false
+
+    ThingRelationships:
+      type: object
+      properties:
+        example: { $ref: "#/components/x-rest-common/schemas/Relationship" }
+      additionalProperties: false
+
+    ThingCollection:
+      type: array
+
+    ThingAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of this instance of thing.
+          example: thing
+        created:
+          type: string
+          description: Timestamp when this instance of thing was created.
+          format: date-time
+          example: "2021-10-05T13:23:17Z"
+        updated:
+          type: string
+          description: Timestamp when this instance of thing was last updated.
+          format: date-time
+          example: "2021-10-05T13:25:29Z"
+        description:
+          type: string
+          description: User-friendly description of this instance of thing.
+          example: "This is a thing named thing."
+      additionalProperties: false


### PR DESCRIPTION
Demonstrates two failure cases which need improved error responses.

When the `items:` property of a schema is missing for `type: array`,
Sweater Comb fails with errors that are hard to parse:

```
$ node build/index.js compare --to ./end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-missing-items.yaml  --context "$(cat ./end-end-tests/api-standards/context.json)"
Loading spec files
Specs loaded - running comparison
Comparing Empty Spec to ./end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-missing-items.yaml

Cannot use 'in' operator to search for '$ref' in undefined
```

If the type of `items:` is invalid, sweater-comb crashes:

```
zksnyk:sweater-comb cmars$ node build/index.js compare --to ./end-end-tests/api-standards/resources/thing/2021-11-10/000-fail-array-invalid-items.yaml --context "$(cat ./end-end-tests/api-standards/context.json)"
Loading spec files
Stopping. Could not load two specifications to compare
Error: [{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data/items","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data/items","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data/items","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data/items","schemaPath":"#/properties/items/anyOf/1/type","keyword":"type","params":{"type":"array"},"message":"must be array"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data/items","schemaPath":"#/properties/items/anyOf","keyword":"anyOf","params":{},"message":"must match a schema in anyOf"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data","schemaPath":"#/required","keyword":"required","params":{"missingProperty":"$ref"},"message":"must have required property '$ref'"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"type"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"items"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema/properties/data","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema","schemaPath":"#/required","keyword":"required","params":{"missingProperty":"$ref"},"message":"must have required property '$ref'"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"type"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"description"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"properties"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200/content/application~1vnd.api+json/schema","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200","schemaPath":"#/required","keyword":"required","params":{"missingProperty":"$ref"},"message":"must have required property '$ref'"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"description"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"headers"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"content"},"message":"must NOT have additional properties"},{"instancePath":"/paths/~1orgs~1{org_id}~1thing/get/responses/200","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data/items","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data/items","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data/items","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data/items","schemaPath":"#/properties/items/anyOf/1/type","keyword":"type","params":{"type":"array"},"message":"must be array"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data/items","schemaPath":"#/properties/items/anyOf","keyword":"anyOf","params":{},"message":"must match a schema in anyOf"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data","schemaPath":"#/required","keyword":"required","params":{"missingProperty":"$ref"},"message":"must have required property '$ref'"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"type"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"items"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollectionResponse/properties/data","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/components/schemas/ThingCollectionResponse","schemaPath":"#/required","keyword":"required","params":{"missingProperty":"$ref"},"message":"must have required property '$ref'"},{"instancePath":"/components/schemas/ThingCollectionResponse","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"type"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollectionResponse","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"description"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollectionResponse","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"properties"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollectionResponse","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/components/schemas/ThingCollection/items","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"},{"instancePath":"/components/schemas/ThingCollection/items","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"},{"instancePath":"/components/schemas/ThingCollection/items","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"},{"instancePath":"/components/schemas/ThingCollection/items","schemaPath":"#/properties/items/anyOf/1/type","keyword":"type","params":{"type":"array"},"message":"must be array"},{"instancePath":"/components/schemas/ThingCollection/items","schemaPath":"#/properties/items/anyOf","keyword":"anyOf","params":{},"message":"must match a schema in anyOf"},{"instancePath":"/components/schemas/ThingCollection","schemaPath":"#/required","keyword":"required","params":{"missingProperty":"$ref"},"message":"must have required property '$ref'"},{"instancePath":"/components/schemas/ThingCollection","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"type"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollection","schemaPath":"#/additionalProperties","keyword":"additionalProperties","params":{"additionalProperty":"items"},"message":"must NOT have additional properties"},{"instancePath":"/components/schemas/ThingCollection","schemaPath":"#/oneOf","keyword":"oneOf","params":{"passingSchemas":null},"message":"must match exactly one schema in oneOf"}]
    at validateOpenApiV3Document (/Users/cmars/Projects/sweater-comb/node_modules/@useoptic/openapi-utilities/build/openapi3/implementations/openapi3/validator.js:17:15)
    at /Users/cmars/Projects/sweater-comb/node_modules/@useoptic/api-checks/build/ci-cli/commands/compare/compare.js:120:63
    at async Promise.all (index 1)
```