### PR TITLE
chore: migrate lifecycle rules to rule authoring v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@useoptic/api-checks": "0.25.2",
-    "@useoptic/optic-ci": "0.25.2",
-    "@useoptic/json-pointer-helpers": "0.25.2",
-    "@useoptic/openapi-cli": "0.25.2",
-    "@useoptic/openapi-io": "0.25.2",
-    "@useoptic/openapi-utilities": "0.25.2",
-    "@useoptic/rulesets-base": "0.25.2",
+    "@useoptic/api-checks": "0.25.3",
+    "@useoptic/optic-ci": "0.25.3",
+    "@useoptic/json-pointer-helpers": "0.25.3",
+    "@useoptic/openapi-cli": "0.25.3",
+    "@useoptic/openapi-io": "0.25.3",
+    "@useoptic/openapi-utilities": "0.25.3",
+    "@useoptic/rulesets-base": "0.25.3",
     "chai": "^4.3.4",
     "chalk": "^4.0.0",
     "change-case": "^4.1.2",
@@ -72,6 +72,9 @@
     "urijs": "^1.19.11"
   },
   "jest": {
+    "testMatch": [
+      "<rootDir>/src/**/*.{spec,test}.{js,ts}"
+    ],
     "testPathIgnorePatterns": [
       "build",
       "node_modules"

--- a/src/rulesets-new/__tests__/__snapshots__/lifecycle-rules.test.ts.snap
+++ b/src/rulesets-new/__tests__/__snapshots__/lifecycle-rules.test.ts.snap
@@ -1,0 +1,713 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lifecycle rules stability a valid stability is provided - beta 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "beta",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "beta",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules stability a valid stability is provided - experimental 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "experimental",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "experimental",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules stability a valid stability is provided - ga 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "ga",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "ga",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules stability a valid stability is provided - wip 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "wip",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "wip",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules stability an invalid stability is provided 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "published",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": "published must be one of allowed values wip, experimental, beta, ga",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": false,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "published",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules stability can not change from any stability but wip 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "beta",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "beta",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "ga",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": "stability transition from '[object Object]' to '[object Object]' not allowed",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": false,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules stability wip can be changed to another maturity 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-snyk-api-stability": "ga",
+      },
+    },
+    "condition": "be provided for every resource document",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#stability-levels",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "ga",
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-snyk-api-stability": "wip",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+]
+`;
+
+exports[`lifecycle rules sunset fails when the file was removed and not deprecated 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-optic-ci-empty-spec": true,
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-optic-ci-empty-spec": true,
+      },
+    },
+    "condition": "follow sunset rules",
+    "docsLink": undefined,
+    "error": "expected Example to be deprecated before removing",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "sunset rules",
+    "passed": false,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+]
+`;
+
+exports[`lifecycle rules sunset schedule fails when the schedule isn't met 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-optic-ci-empty-spec": true,
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-optic-ci-empty-spec": true,
+      },
+    },
+    "condition": "follow sunset rules",
+    "docsLink": undefined,
+    "error": "expected beta resource Example to be deprecated 90 days",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "sunset rules",
+    "passed": false,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+]
+`;
+
+exports[`lifecycle rules sunset schedule passes when the schedule is met 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+          "x-optic-ci-empty-spec": true,
+        },
+        "before": Object {
+          "info": Object {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.3",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": "not change unless it was wip",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#promoting-stability-of-a-resource-over-time",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource stability transitions",
+    "passed": true,
+    "received": undefined,
+    "where": "changed specification",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {},
+        "conceptualPath": Array [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": Object {
+        "info": Object {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.3",
+        "x-optic-ci-empty-spec": true,
+      },
+    },
+    "condition": "follow sunset rules",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "sunset rules",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for specification",
+  },
+]
+`;

--- a/src/rulesets-new/__tests__/fixtures.ts
+++ b/src/rulesets-new/__tests__/fixtures.ts
@@ -1,0 +1,9 @@
+export const context = {
+  changeDate: "2021-10-10",
+  changeResource: "Example",
+  changeVersion: {
+    date: "2021-10-10",
+    stability: "ga",
+  },
+  resourceVersions: {},
+};

--- a/src/rulesets-new/__tests__/lifecycle-rules.test.ts
+++ b/src/rulesets-new/__tests__/lifecycle-rules.test.ts
@@ -22,7 +22,7 @@ describe("lifecycle rules", () => {
         };
         const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
-        expect(results.length > 0).toBe(true);
+        expect(results.length).toBeGreaterThan(0);
         expect(results.every((result) => result.passed)).toBe(true);
         expect(results).toMatchSnapshot();
       },
@@ -39,7 +39,7 @@ describe("lifecycle rules", () => {
       };
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
-      expect(results.length > 0).toBe(true);
+      expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(false);
       expect(results).toMatchSnapshot();
     });
@@ -61,7 +61,7 @@ describe("lifecycle rules", () => {
       };
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
-      expect(results.length > 0).toBe(true);
+      expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(true);
       expect(results).toMatchSnapshot();
     });
@@ -83,7 +83,7 @@ describe("lifecycle rules", () => {
       };
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
-      expect(results.length > 0).toBe(true);
+      expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(false);
       expect(results).toMatchSnapshot();
     });
@@ -100,7 +100,7 @@ describe("lifecycle rules", () => {
         context,
       };
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length > 0).toBe(true);
+      expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(false);
       expect(results).toMatchSnapshot();
     });
@@ -137,7 +137,7 @@ describe("lifecycle rules", () => {
           context: sunsetContext,
         };
         const results = ruleRunner.runRulesWithFacts(ruleInputs);
-        expect(results.length > 0).toBe(true);
+        expect(results.length).toBeGreaterThan(0);
         expect(results.every((result) => result.passed)).toBe(false);
         expect(results).toMatchSnapshot();
       });
@@ -152,7 +152,7 @@ describe("lifecycle rules", () => {
           context: { ...sunsetContext, changeDate: "2022-02-01" },
         };
         const results = ruleRunner.runRulesWithFacts(ruleInputs);
-        expect(results.length > 0).toBe(true);
+        expect(results.length).toBeGreaterThan(0);
         expect(results.every((result) => result.passed)).toBe(true);
         expect(results).toMatchSnapshot();
       });

--- a/src/rulesets-new/__tests__/lifecycle-rules.test.ts
+++ b/src/rulesets-new/__tests__/lifecycle-rules.test.ts
@@ -1,0 +1,161 @@
+import { OpenAPIV3 } from "@useoptic/openapi-utilities";
+import { RuleRunner, TestHelpers } from "@useoptic/rulesets-base";
+import { context } from "./fixtures";
+
+import { lifecycleRuleset } from "../lifecycle-rules";
+import { stabilityKey } from "../constants";
+
+const baseJson = TestHelpers.createEmptySpec();
+
+describe("lifecycle rules", () => {
+  describe("stability", () => {
+    test.each(["wip", "experimental", "beta", "ga"])(
+      "a valid stability is provided - %s",
+      (stability) => {
+        const ruleRunner = new RuleRunner([lifecycleRuleset]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, {
+            ...baseJson,
+            [stabilityKey]: stability,
+          } as OpenAPIV3.Document),
+          context,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+        expect(results.length > 0).toBe(true);
+        expect(results.every((result) => result.passed)).toBe(true);
+        expect(results).toMatchSnapshot();
+      },
+    );
+
+    test("an invalid stability is provided", () => {
+      const ruleRunner = new RuleRunner([lifecycleRuleset]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          [stabilityKey]: "published",
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length > 0).toBe(true);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("wip can be changed to another maturity", () => {
+      const ruleRunner = new RuleRunner([lifecycleRuleset]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(
+          {
+            ...baseJson,
+            [stabilityKey]: "wip",
+          } as OpenAPIV3.Document,
+          {
+            ...baseJson,
+            [stabilityKey]: "ga",
+          } as OpenAPIV3.Document,
+        ),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length > 0).toBe(true);
+      expect(results.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("can not change from any stability but wip", () => {
+      const ruleRunner = new RuleRunner([lifecycleRuleset]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(
+          {
+            ...baseJson,
+            [stabilityKey]: "ga",
+          } as OpenAPIV3.Document,
+          {
+            ...baseJson,
+            [stabilityKey]: "beta",
+          } as OpenAPIV3.Document,
+        ),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length > 0).toBe(true);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("sunset", () => {
+    test("fails when the file was removed and not deprecated", () => {
+      const ruleRunner = new RuleRunner([lifecycleRuleset]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          ["x-optic-ci-empty-spec"]: true,
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length > 0).toBe(true);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+
+    describe("schedule", () => {
+      const sunsetContext = {
+        changeDate: "2021-10-20",
+        changeResource: "Example",
+        changeVersion: {
+          date: "2021-10-10",
+          stability: "beta",
+        },
+        resourceVersions: {
+          Example: {
+            "2021-10-10": {
+              beta: {
+                deprecatedBy: {
+                  date: "2021-10-20",
+                  stability: "ga",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      test("fails when the schedule isn't met", () => {
+        const ruleRunner = new RuleRunner([lifecycleRuleset]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, {
+            ...baseJson,
+            ["x-optic-ci-empty-spec"]: true,
+          } as OpenAPIV3.Document),
+          context: sunsetContext,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length > 0).toBe(true);
+        expect(results.every((result) => result.passed)).toBe(false);
+        expect(results).toMatchSnapshot();
+      });
+
+      test("passes when the schedule is met", () => {
+        const ruleRunner = new RuleRunner([lifecycleRuleset]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, {
+            ...baseJson,
+            ["x-optic-ci-empty-spec"]: true,
+          } as OpenAPIV3.Document),
+          context: { ...sunsetContext, changeDate: "2022-02-01" },
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length > 0).toBe(true);
+        expect(results.every((result) => result.passed)).toBe(true);
+        expect(results).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/rulesets-new/constants.ts
+++ b/src/rulesets-new/constants.ts
@@ -1,0 +1,1 @@
+export const stabilityKey = "x-snyk-api-stability";

--- a/src/rulesets-new/lifecycle-rules.ts
+++ b/src/rulesets-new/lifecycle-rules.ts
@@ -1,0 +1,112 @@
+import { RuleError, Ruleset, SpecificationRule } from "@useoptic/rulesets-base";
+import { links } from "../docs";
+import { stabilityKey } from "./constants";
+
+const stabilityRequirement = new SpecificationRule({
+  name: "resource stability",
+  docsLink: links.versioning.stabilityLevels,
+  matches: (specification, rulesContext) =>
+    rulesContext.specification.change !== "removed",
+  rule: (specificationAssertions) => {
+    specificationAssertions.requirement(
+      "be provided for every resource document",
+      (specification) => {
+        const stability: string | undefined = specification.value[stabilityKey];
+        const allowed = ["wip", "experimental", "beta", "ga"];
+        if (!stability || !allowed.includes(stability)) {
+          throw new RuleError({
+            message: `${stability} must be one of allowed values ${allowed.join(
+              ", ",
+            )}`,
+          });
+        }
+      },
+    );
+  },
+});
+
+const stabilityTransitions = new SpecificationRule({
+  name: "resource stability transitions",
+  docsLink: links.versioning.promotingStability,
+  rule: (specificationAssertions) => {
+    specificationAssertions.changed(
+      "not change unless it was wip",
+      (before, after) => {
+        const beforeStability: string | undefined = before.value[stabilityKey];
+        const afterStability: string | undefined = after.value[stabilityKey];
+        // When there is no `before`, it means it's a new file. Any stability is allowed.
+        // When there is no `after`, it means it's been deleted and sunset rules should apply in another rule.
+        if (!beforeStability || !afterStability) return;
+        // A resource can go from wip to anything, so no need to check.
+        if (beforeStability === "wip") return;
+
+        if (beforeStability !== afterStability) {
+          throw new RuleError({
+            message: `stability transition from '${before}' to '${after}' not allowed`,
+          });
+        }
+      },
+    );
+  },
+});
+
+const followSunsetRules = new SpecificationRule({
+  name: "sunset rules",
+  matches: (specification, rulesContext) => {
+    return (
+      !(
+        specification.value[stabilityKey] === "wip" ||
+        specification.value[stabilityKey] === "experimental"
+      ) && rulesContext.specification.change === "removed"
+    );
+  },
+  rule: (specificationAssertions, rulesContext) => {
+    specificationAssertions.requirement("follow sunset rules", () => {
+      const {
+        resourceVersions,
+        changeResource: resourceName,
+        changeVersion: { date, stability },
+        changeDate,
+      } = rulesContext.custom;
+
+      const deprecatedBy =
+        resourceVersions?.[resourceName]?.[date]?.[stability]?.deprecatedBy;
+
+      if (!deprecatedBy) {
+        throw new RuleError({
+          message: `expected ${resourceName} to be deprecated before removing`,
+        });
+      }
+
+      const contextDate = new Date(changeDate);
+      const resourceDate = new Date(date);
+
+      const diffDays =
+        (contextDate.getTime() - resourceDate.getTime()) /
+        (1000 * 60 * 60 * 24);
+
+      // Number of days required before a resource can be removed
+      const sunsetSchedule = {
+        beta: 90,
+        ga: 180,
+      };
+      const requiredDays = sunsetSchedule[stability];
+
+      if (!requiredDays) {
+        throw new RuleError({
+          message: `unexpected stability ${stability} in ${resourceName}`,
+        });
+      }
+      if (diffDays < requiredDays) {
+        throw new RuleError({
+          message: `expected ${stability} resource ${resourceName} to be deprecated ${requiredDays} days`,
+        });
+      }
+    });
+  },
+});
+
+export const lifecycleRuleset = new Ruleset({
+  name: "api lifecycle ruleset",
+  rules: [stabilityRequirement, stabilityTransitions, followSunsetRules],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,6 +1057,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
@@ -2214,19 +2221,19 @@
     "@typescript-eslint/types" "5.18.0"
     eslint-visitor-keys "^3.0.0"
 
-"@useoptic/api-checks@0.25.2", "@useoptic/api-checks@^0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.25.2.tgz#57bbe60c35bd590659d0bc703e9df4e14a3c6481"
-  integrity sha512-Mt8euJl2QiQB6xPs1OQYdxKt07bldi92Fcw21YcOp0zA+KYKSrc2KDcHSdDQARi7bt0QX7+LTw2HjRWY97nPDQ==
+"@useoptic/api-checks@0.25.3", "@useoptic/api-checks@^0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/api-checks/-/api-checks-0.25.3.tgz#37770d34ed2690798ad8730c1a92da74621923bb"
+  integrity sha512-UejAU+THnfNkTaPtz2lCyu9zrnYApC/g++THZS/j46rbM16DSrRpk26RPEAruZFfkmDcLhIRcy8AIc+UvUbtUA==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@octokit/rest" "^18.12.0"
     "@sentry/node" "^6.15.0"
     "@stoplight/spectral-core" "^1.8.1"
     "@stoplight/spectral-rulesets" "^1.3.2"
-    "@useoptic/json-pointer-helpers" "0.25.2"
-    "@useoptic/openapi-io" "0.25.2"
-    "@useoptic/openapi-utilities" "0.25.2"
+    "@useoptic/json-pointer-helpers" "0.25.3"
+    "@useoptic/openapi-io" "0.25.3"
+    "@useoptic/openapi-utilities" "0.25.3"
     analytics-node "^6.0.0"
     chai "^4.3.4"
     chalk "^4.1.2"
@@ -2246,21 +2253,21 @@
     url-join "^4.0.1"
     uuid "^8.3.2"
 
-"@useoptic/json-pointer-helpers@0.25.2", "@useoptic/json-pointer-helpers@^0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.25.2.tgz#6862157e96818c519e5ff3539a6f6e3379b2f0dd"
-  integrity sha512-uhVJ/wWx1aUKt/KYHTTTmY88tMkESmIQEwH//Qsfn370TeLuY38vcW+Bt7aNw16QwRnRwohEkf8lVn/5cUzsOA==
+"@useoptic/json-pointer-helpers@0.25.3", "@useoptic/json-pointer-helpers@^0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.25.3.tgz#f2e8d5390150fae7bcb0806a9ec7dd84d0b421b1"
+  integrity sha512-JHeoBcW+9YcrMroDWtLwJcrek57MyEjz8sdDPnW/Ugqih6Dc5B+K7H6HqpDnSk+G6FmwJFAyG6FQ59oITTD8IQ==
   dependencies:
     jsonpointer "^5.0.0"
 
-"@useoptic/openapi-cli@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-cli/-/openapi-cli-0.25.2.tgz#c9219e1c4e709f125ba4f1ebadd738d8a3547508"
-  integrity sha512-EgnbEfU2VBasSM443zK/oFj84cRDuZmLX/RM2VIcowQSE+3x44xwnPovdSi51JmGHWuiMGRD7ldNDWiImlpbcQ==
+"@useoptic/openapi-cli@0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-cli/-/openapi-cli-0.25.3.tgz#b8a3f4e39121f511499c6107f15566b55128eb2d"
+  integrity sha512-mJQfKw5+BLYKyMfYvBAno4c1E/Zui0Rryy26ewGBaqdUkN88KrcuGQ4aYnFcKwJGWtqBcENmgNhTYxSoSrTmeA==
   dependencies:
-    "@useoptic/json-pointer-helpers" "0.25.2"
-    "@useoptic/openapi-io" "0.25.2"
-    "@useoptic/openapi-utilities" "0.25.2"
+    "@useoptic/json-pointer-helpers" "0.25.3"
+    "@useoptic/openapi-io" "0.25.3"
+    "@useoptic/openapi-utilities" "0.25.3"
     analytics-node "^6.0.0"
     axax "^0.2.2"
     commander "^9.0.0"
@@ -2271,15 +2278,15 @@
     ts-invariant "^0.9.4"
     ts-results "^3.3.0"
 
-"@useoptic/openapi-io@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.25.2.tgz#d2394faa617eea93029f45f7575fddba7a140c8e"
-  integrity sha512-DYMNJoYYgqwSB6j1W3gepqICEf4oxdWyAn8D5SEDr3UxFOUMlfkjKiBepdnhhyhRzVCatAk7lOkHrbaYk3FYvg==
+"@useoptic/openapi-io@0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-io/-/openapi-io-0.25.3.tgz#27af70f53fce200b23caa59297e5c1740bafda36"
+  integrity sha512-jtFU4XSR8oLB8CuZVJVP1Tf5kNi+EMSE7vphCvZp0ZN3c1qZK0ahIJhmwpMobiaLHkVu4cJRzHUr0Fc57Rz4fQ==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@jsdevtools/ono" "^7.1.3"
-    "@useoptic/json-pointer-helpers" "0.25.2"
-    "@useoptic/openapi-utilities" "0.25.2"
+    "@useoptic/json-pointer-helpers" "0.25.3"
+    "@useoptic/openapi-utilities" "0.25.3"
     copyfiles "^2.4.1"
     crypto-js "^4.1.1"
     fast-deep-equal "^3.1.3"
@@ -2294,12 +2301,12 @@
     ts-invariant "^0.9.3"
     yaml-ast-parser "^0.0.43"
 
-"@useoptic/openapi-utilities@0.25.2", "@useoptic/openapi-utilities@^0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.25.2.tgz#45f056899437d5e3ba6a94087ef7b006352bf109"
-  integrity sha512-rimoMfrwS6SBdba2KZ2wTu+zZrtb+e0DRNOBMp4Hoa/L1mhzoomKta3IwPadYBx4FNC3xLW4eCcMKnBYFj5NQA==
+"@useoptic/openapi-utilities@0.25.3", "@useoptic/openapi-utilities@^0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/openapi-utilities/-/openapi-utilities-0.25.3.tgz#38824443381658033aa1f96de3fe89514cda6992"
+  integrity sha512-nXTzRwm4AMXs85zA4lZHWPuBQT2hEtOIZt12tmg/GhQ/cd3NCmw7E7cO9hn1aUPrGbn1eqAbDzNtC9wsccjIjw==
   dependencies:
-    "@useoptic/json-pointer-helpers" "0.25.2"
+    "@useoptic/json-pointer-helpers" "0.25.3"
     fast-deep-equal "^3.1.3"
     js-yaml "^4.1.0"
     lodash.isequal "^4.5.0"
@@ -2309,21 +2316,21 @@
     ts-invariant "^0.9.3"
     yaml-ast-parser "^0.0.43"
 
-"@useoptic/optic-ci@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/optic-ci/-/optic-ci-0.25.2.tgz#c49cbe71a7759bf1abb3797ce455aa2fe81bea91"
-  integrity sha512-pvNz8dMrJ7WC/JxX+VXKUnIxhFtxypC1q5wLmGZOGNPL6S9frs+KuKsEb/NFTUPlVaHf3jpevlH7FyCEX/sY9w==
+"@useoptic/optic-ci@0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/optic-ci/-/optic-ci-0.25.3.tgz#e0fc0f037dab3558ee0e1e6e2d4d04aee15bd923"
+  integrity sha512-KZWhAi3EqrJDecBdcMjNHYsyQiznc5X8/PSYsik5MMDt0rbPMdUgFc3lEO1pe3UZH5nF7t1giFgCR2xugpDGlw==
   dependencies:
-    "@useoptic/api-checks" "0.25.2"
+    "@useoptic/api-checks" "0.25.3"
 
-"@useoptic/rulesets-base@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@useoptic/rulesets-base/-/rulesets-base-0.25.2.tgz#5c6b9749781e8cf1060faa20fa3ef7966f778ae9"
-  integrity sha512-jw90jExzfTVK140X8vmVPIfMUg8hcdCd+BlHP/rHzZKRBxxZsZAnt3/CmhyCUO3vP5JqUdLBacRqVPdmR5wHLQ==
+"@useoptic/rulesets-base@0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@useoptic/rulesets-base/-/rulesets-base-0.25.3.tgz#a1a152f70a3242c6507447cc31be14953f8b838e"
+  integrity sha512-AW2QGLvqBEDF8w0eZDm/v4+a1hk/nsFy6X8DdeA02FOu4gfp+7HWM+Vczv5EKEbihqeb5BGtXgU+tr8yPiMVvg==
   dependencies:
-    "@useoptic/api-checks" "^0.25.2"
-    "@useoptic/json-pointer-helpers" "^0.25.2"
-    "@useoptic/openapi-utilities" "^0.25.2"
+    "@useoptic/api-checks" "^0.25.3"
+    "@useoptic/json-pointer-helpers" "^0.25.3"
+    "@useoptic/openapi-utilities" "^0.25.3"
     lodash.pick "^4.4.0"
 
 JSONStream@^1.0.4:
@@ -7323,10 +7330,10 @@ yargs@^17.0.0:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-yargs@^17.3.0:
-  version "17.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.0.tgz#295c4ffd0eef148ef3e48f7a2e0f58d0e4f26b1c"
-  integrity sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==
+yargs@^17.4.1:
+  version "17.5.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.0.tgz#2706c5431f8c119002a2b106fc9f58b9bb9097a3"
+  integrity sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
Migrating the [lifecycle rules](https://github.com/snyk/sweater-comb/blob/main/src/rulesets/api-lifeycle.ts) in this PR

I'm going to be incrementally migrating over the rules file by file, since that'll be the easiest way to sure to migrate everything and to verify the functionality between these. I'm copying over the test files which should produce very similar snapshots (there are some location improvements with the new rules API)

this should generally be very similar to the old API with a few changes / improvements - I'll annotate them in code as I open up PRs as relevant