### PR TITLE
chore: migrate operation rules to rule authoring v2

### DIFF
--- a/src/rulesets-new/__tests__/__snapshots__/operation-rules.test.ts.snap
+++ b/src/rulesets-new/__tests__/__snapshots__/operation-rules.test.ts.snap
@@ -1,0 +1,6333 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`operation metadata fails if summary is missing 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": "Expected a partial match",
+    "expected": "{\\"summary\\":\\"Matcher.string\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": false,
+    "received": "{\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"operationId\\":\\"getExample\\",\\"responses\\":{}}",
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operation metadata fails if tags is not supplied 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": "Expected a partial match",
+    "expected": "{\\"tags\\":[\\"Matcher.string\\"]}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"operationId\\":\\"getExample\\",\\"responses\\":{}}",
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operation parameters allows adding a required query parameter to a new operation 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "required",
+        "required": true,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: required in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operation parameters fails if the default value is changed 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "after",
+            "type": "string",
+          },
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "before",
+            "type": "string",
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not be required",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing optional query parameter to required",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: query_parameter in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "after",
+            "type": "string",
+          },
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "before",
+            "type": "string",
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the default value",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#breaking-changes",
+    "error": "default schema was changed from before to after",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter default value",
+    "passed": false,
+    "received": undefined,
+    "where": "changed query parameter: query_parameter in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "after",
+            "type": "string",
+          },
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "before",
+            "type": "string",
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the schema format",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter schema format",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: query_parameter in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "after",
+            "type": "string",
+          },
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "before",
+            "type": "string",
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the schema format",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter schema pattern",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: query_parameter in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "after",
+            "type": "string",
+          },
+        },
+        "before": Object {
+          "in": "query",
+          "name": "query_parameter",
+          "schema": Object {
+            "default": "before",
+            "type": "string",
+          },
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "query_parameter",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "query_parameter",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the schema format",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter schema type",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: query_parameter in operation: GET /example",
+  },
+]
+`;
+
+exports[`operation parameters fails when adding a required query parameter 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "required",
+        "required": true,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: required in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "required",
+        "required": true,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not be required",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#breaking-changes",
+    "error": "expected request query parameter required to not be required",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding required query parameter",
+    "passed": false,
+    "received": undefined,
+    "where": "added query parameter: required in operation: GET /example",
+  },
+]
+`;
+
+exports[`operation parameters fails when changing optional to required query parameter 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "required",
+          "required": true,
+        },
+        "before": Object {
+          "in": "query",
+          "name": "required",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not be required",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#breaking-changes",
+    "error": "expected request query parameter true to not change from optional to required",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing optional query parameter to required",
+    "passed": false,
+    "received": undefined,
+    "where": "changed query parameter: required in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "required",
+          "required": true,
+        },
+        "before": Object {
+          "in": "query",
+          "name": "required",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the default value",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter default value",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: required in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "required",
+          "required": true,
+        },
+        "before": Object {
+          "in": "query",
+          "name": "required",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the schema format",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter schema format",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: required in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "required",
+          "required": true,
+        },
+        "before": Object {
+          "in": "query",
+          "name": "required",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the schema format",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter schema pattern",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: required in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "in": "query",
+          "name": "required",
+          "required": true,
+        },
+        "before": Object {
+          "in": "query",
+          "name": "required",
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "required",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "required",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/1",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "not change the schema format",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing parameter schema type",
+    "passed": true,
+    "received": undefined,
+    "where": "changed query parameter: required in operation: GET /example",
+  },
+]
+`;
+
+exports[`operation parameters names fails if the case is not correct 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "pathParameter",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "pathParameter",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "pathParameter",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": "expected parameter name pathParameter to be snake case",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": false,
+    "received": undefined,
+    "where": "added path parameter: pathParameter in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "pathParameter",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "pathParameter",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "pathParameter",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: pathParameter in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+]
+`;
+
+exports[`operation parameters names passes if the case is correct 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "path_parameter",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "path_parameter",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "path_parameter",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added path parameter: path_parameter in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "path_parameter",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "path_parameter",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "path_parameter",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: path_parameter in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+]
+`;
+
+exports[`operation parameters passes if the default value is changed in experimental 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operation parameters passes when changing optional to required query parameter in experimental 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId missing fails if empty string 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.camel case and starts with get|create|list|update|delete matcher\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"operationId\\":\\"\\",\\"responses\\":{}}",
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId missing fails if undefined 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.camel case and starts with get|create|list|update|delete matcher\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"responses\\":{}}",
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.string\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"responses\\":{}}",
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId when set fails if changed 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "method": "get",
+          "operationId": "getExampleButDifferent",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+        "before": Object {
+          "method": "get",
+          "operationId": "getExample",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "changed operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExampleButDifferent",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExampleButDifferent",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExampleButDifferent",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "method": "get",
+          "operationId": "getExampleButDifferent",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+        "before": Object {
+          "method": "get",
+          "operationId": "getExample",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "have consistent operation IDs",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": "operationIds was changed",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "consistent operation ids",
+    "passed": false,
+    "received": undefined,
+    "where": "changed operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExampleButDifferent",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExampleButDifferent",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId when set fails if not camel case 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.camel case and starts with get|create|list|update|delete matcher\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"operationId\\":\\"get-hello-world\\",\\"responses\\":{}}",
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get-hello-world",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId when set fails if prefix is wrong 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.camel case and starts with get|create|list|update|delete matcher\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"operationId\\":\\"findHelloWorld\\",\\"responses\\":{}}",
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "findHelloWorld",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId when set fails if removed 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "method": "get",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+        "before": Object {
+          "method": "get",
+          "operationId": "getExample",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.camel case and starts with get|create|list|update|delete matcher\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"responses\\":{}}",
+    "where": "changed operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.string\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"responses\\":{}}",
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "method": "get",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+        "before": Object {
+          "method": "get",
+          "operationId": "getExample",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "have consistent operation IDs",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": "operationIds was changed",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "consistent operation ids",
+    "passed": false,
+    "received": undefined,
+    "where": "changed operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId when set fails when camel case and valid prefix but no suffix 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": "Expected a partial match",
+    "expected": "{\\"operationId\\":\\"Matcher.camel case and starts with get|create|list|update|delete matcher\\"}",
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": false,
+    "received": "{\\"summary\\":\\"this is an example\\",\\"tags\\":[\\"example\\"],\\"parameters\\":[{\\"name\\":\\"version\\",\\"in\\":\\"query\\"}],\\"operationId\\":\\"get\\",\\"responses\\":{}}",
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "get",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`operationId when set passes when camel case and has a hump 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getYesHump",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`passes when operation is set correctly 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`put method fails adding put method 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/put/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": "put is not allowed in JSON:API",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": false,
+    "received": undefined,
+    "where": "added operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: PUT /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "put",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "put",
+        ],
+        "jsonPath": "/paths/~1example/put",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "put",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: PUT /example",
+  },
+]
+`;
+
+exports[`status codes fails when status code is removed 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "changeType": "removed",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200",
+        "kind": "response",
+      },
+      "removed": Object {
+        "before": Object {
+          "description": "123",
+          "statusCode": "200",
+        },
+      },
+    },
+    "condition": "not be removed",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#breaking-changes",
+    "error": "must not remove response status code",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent removing status codes",
+    "passed": false,
+    "received": undefined,
+    "where": "removed response status code: 200 in operation: GET /example",
+  },
+]
+`;
+
+exports[`version parameter fails when there is no version parameter 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": "Could not find a partial match in query parameters",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": false,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;

--- a/src/rulesets-new/__tests__/operation-rules.test.ts
+++ b/src/rulesets-new/__tests__/operation-rules.test.ts
@@ -1,0 +1,739 @@
+import { OpenAPIV3 } from "@useoptic/openapi-utilities";
+import { RuleRunner, TestHelpers } from "@useoptic/rulesets-base";
+import { context } from "./fixtures";
+
+import { operationRules } from "../operation-rules";
+
+const baseJson = TestHelpers.createEmptySpec();
+test("passes when operation is set correctly", () => {
+  const ruleRunner = new RuleRunner([operationRules]);
+  const ruleInputs = {
+    ...TestHelpers.createRuleInputs(baseJson, {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+            ],
+            operationId: "getExample",
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document),
+    context,
+  };
+  const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+  expect(results.length).toBeGreaterThan(0);
+  expect(results.every((result) => result.passed)).toBe(true);
+  expect(results).toMatchSnapshot();
+});
+
+describe("operationId", () => {
+  describe("missing", () => {
+    test("fails if empty string", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          paths: {
+            "/example": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                ],
+                operationId: "",
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if undefined", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          paths: {
+            "/example": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                ],
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("when set", () => {
+    test.each([
+      ["fails if prefix is wrong", "findHelloWorld", false],
+      ["fails if not camel case", "get-hello-world", false],
+      ["fails when camel case and valid prefix but no suffix", "get", false],
+      ["passes when camel case and has a hump", "getYesHump", true],
+    ])("%s", (_, operationId, shouldPass) => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          paths: {
+            "/example": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                ],
+                operationId: operationId,
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(shouldPass);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if removed", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(
+          {
+            ...baseJson,
+            paths: {
+              "/example": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                  ],
+                  operationId: "getExample",
+                  responses: {},
+                },
+              },
+            },
+          } as OpenAPIV3.Document,
+          {
+            ...baseJson,
+            paths: {
+              "/example": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                  ],
+                  responses: {},
+                },
+              },
+            },
+          } as OpenAPIV3.Document,
+        ),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length).toBeGreaterThan(0);
+
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if changed", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(
+          {
+            ...baseJson,
+            paths: {
+              "/example": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                  ],
+                  operationId: "getExample",
+                  responses: {},
+                },
+              },
+            },
+          } as OpenAPIV3.Document,
+          {
+            ...baseJson,
+            paths: {
+              "/example": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                  ],
+                  operationId: "getExampleButDifferent",
+                  responses: {},
+                },
+              },
+            },
+          } as OpenAPIV3.Document,
+        ),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+      expect(results.length).toBeGreaterThan(0);
+
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+  });
+});
+
+describe("operation metadata", () => {
+  test("fails if summary is missing", () => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, {
+        ...baseJson,
+        paths: {
+          "/example": {
+            get: {
+              tags: ["example"],
+              parameters: [
+                {
+                  name: "version",
+                  in: "query",
+                },
+              ],
+              operationId: "getExample",
+              responses: {},
+            },
+          },
+        },
+      } as OpenAPIV3.Document),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+    expect(results.length).toBeGreaterThan(0);
+
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+
+  test("fails if tags is not supplied", () => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, {
+        ...baseJson,
+        paths: {
+          "/example": {
+            get: {
+              summary: "this is an example",
+              tags: [],
+              parameters: [
+                {
+                  name: "version",
+                  in: "query",
+                },
+              ],
+              operationId: "getExample",
+              responses: {},
+            },
+          },
+        },
+      } as OpenAPIV3.Document),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+    expect(results.length).toBeGreaterThan(0);
+
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+});
+
+describe("operation parameters", () => {
+  describe("names", () => {
+    test("fails if the case is not correct", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          paths: {
+            "/example/{pathParameter}": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                  {
+                    name: "pathParameter",
+                    in: "path",
+                  },
+                ],
+                operationId: "getExample",
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if the case is correct", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, {
+          ...baseJson,
+          paths: {
+            "/example/{path_parameter}": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                  {
+                    name: "path_parameter",
+                    in: "path",
+                  },
+                ],
+                operationId: "getExample",
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+  });
+  test("fails when adding a required query parameter", () => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(
+        {
+          ...baseJson,
+          paths: {
+            "/example": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                ],
+                operationId: "getExample",
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document,
+        {
+          ...baseJson,
+          paths: {
+            "/example": {
+              get: {
+                summary: "this is an example",
+                tags: ["example"],
+                parameters: [
+                  {
+                    name: "version",
+                    in: "query",
+                  },
+                  {
+                    name: "required",
+                    in: "query",
+                    required: true,
+                  },
+                ],
+                operationId: "getExample",
+                responses: {},
+              },
+            },
+          },
+        } as OpenAPIV3.Document,
+      ),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+
+  test("allows adding a required query parameter to a new operation", () => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, {
+        ...baseJson,
+        paths: {
+          "/example": {
+            get: {
+              summary: "this is an example",
+              tags: ["example"],
+              parameters: [
+                {
+                  name: "version",
+                  in: "query",
+                },
+                {
+                  name: "required",
+                  in: "query",
+                  required: true,
+                },
+              ],
+              operationId: "getExample",
+              responses: {},
+            },
+          },
+        },
+      } as OpenAPIV3.Document),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(true);
+    expect(results).toMatchSnapshot();
+  });
+
+  test.each([
+    [
+      "passes when changing optional to required query parameter in experimental",
+      "experimental",
+      true,
+    ],
+    ["fails when changing optional to required query parameter", "ga", false],
+  ])("%s", (_, stability, shouldPass) => {
+    const beforeJson = {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+              {
+                name: "required",
+                in: "query",
+              },
+            ],
+            operationId: "getExample",
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+
+    const afterJson = {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+              {
+                name: "required",
+                in: "query",
+                required: true,
+              },
+            ],
+            operationId: "getExample",
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+    const ruleRunner = new RuleRunner([operationRules]);
+
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(beforeJson, afterJson),
+      context: {
+        ...context,
+        changeVersion: { ...context.changeVersion, stability },
+      },
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(shouldPass);
+    expect(results).toMatchSnapshot();
+  });
+
+  test.each([
+    [
+      "passes if the default value is changed in experimental",
+      "experimental",
+      true,
+    ],
+    ["fails if the default value is changed", "ga", false],
+  ])("%s", (_, stability, shouldPass) => {
+    const beforeJson = {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+              {
+                name: "query_parameter",
+                in: "query",
+                schema: {
+                  type: "string",
+                  default: "before",
+                },
+              },
+            ],
+            operationId: "getExample",
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+
+    const afterJson = {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+              {
+                name: "query_parameter",
+                in: "query",
+                schema: {
+                  type: "string",
+                  default: "after",
+                },
+              },
+            ],
+            operationId: "getExample",
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+    const ruleRunner = new RuleRunner([operationRules]);
+
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(beforeJson, afterJson),
+      context: {
+        ...context,
+        changeVersion: { ...context.changeVersion, stability },
+      },
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(shouldPass);
+    expect(results).toMatchSnapshot();
+  });
+});
+
+describe("status codes", () => {
+  test("fails when status code is removed", () => {
+    const beforeJson = {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+            ],
+            operationId: "getExample",
+            responses: {
+              "200": {
+                description: "123",
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+
+    const afterJson = {
+      ...baseJson,
+      paths: {
+        "/example": {
+          get: {
+            summary: "this is an example",
+            tags: ["example"],
+            parameters: [
+              {
+                name: "version",
+                in: "query",
+              },
+            ],
+            operationId: "getExample",
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(beforeJson, afterJson),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+});
+
+describe("version parameter", () => {
+  test("fails when there is no version parameter", () => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, {
+        ...baseJson,
+        paths: {
+          "/example": {
+            get: {
+              summary: "this is an example",
+              tags: ["example"],
+              operationId: "getExample",
+              responses: {},
+            },
+          },
+        },
+      } as OpenAPIV3.Document),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+});
+
+describe("put method", () => {
+  test("fails adding put method", () => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, {
+        ...baseJson,
+        paths: {
+          "/example": {
+            put: {
+              summary: "this is an example",
+              tags: ["example"],
+              parameters: [
+                {
+                  name: "version",
+                  in: "query",
+                },
+              ],
+              operationId: "getExample",
+              responses: {},
+            },
+          },
+        },
+      } as OpenAPIV3.Document),
+      context,
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+});

--- a/src/rulesets-new/operation-rules.ts
+++ b/src/rulesets-new/operation-rules.ts
@@ -1,0 +1,414 @@
+import { OpenAPIV3 } from "@useoptic/openapi-utilities";
+import {
+  RuleError,
+  Ruleset,
+  OperationRule,
+  Matcher,
+  Matchers,
+  ResponseRule,
+} from "@useoptic/rulesets-base";
+import { camelCase, snakeCase } from "change-case";
+import { links } from "../docs";
+import { isBreakingChangeAllowed } from "./utils";
+
+const operationId = new OperationRule({
+  name: "operation id",
+  docsLink: links.standards.operationIds,
+  matches: (operation, ruleContext) => {
+    const changeDate = new Date(ruleContext.custom.changeVersion.date);
+    const effectiveOnDate = new Date("2021-07-01");
+    return (
+      !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability) &&
+      changeDate > effectiveOnDate
+    );
+  },
+  rule: (operationAssertions) => {
+    const prefixRegex = /^(get|create|list|update|delete)[A-Z]+.*/; // alternatively we could split at camelCase boundaries and assert on the first item
+
+    const operationIdMatcher = new Matcher(
+      (value) =>
+        typeof value === "string" &&
+        value === camelCase(value) &&
+        prefixRegex.test(value),
+      "camel case and starts with get|create|list|update|delete matcher",
+    );
+    operationAssertions.added.matches({
+      operationId: operationIdMatcher,
+    });
+    operationAssertions.changed.matches({
+      operationId: operationIdMatcher,
+    });
+  },
+});
+
+const operationIdSet = new OperationRule({
+  name: "operation id set",
+  docsLink: links.standards.operationIds,
+  rule: (operationAssertions) => {
+    operationAssertions.requirement.matches({
+      operationId: Matchers.string,
+    });
+  },
+});
+
+const tags = new OperationRule({
+  name: "operation tags",
+  docsLink: links.standards.tags,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.requirement.matches({
+      tags: [Matchers.string], // expects at least 1 tag of string
+    });
+  },
+});
+
+const summary = new OperationRule({
+  name: "operation summary",
+  docsLink: links.standards.operationSummary,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.requirement.matches({
+      summary: Matchers.string,
+    });
+  },
+});
+
+const consistentOperationIds = new OperationRule({
+  name: "consistent operation ids",
+  docsLink: links.standards.operationSummary,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.changed(
+      "have consistent operation IDs",
+      (before, after) => {
+        if (before.value.operationId !== after.value.operationId) {
+          throw new RuleError({
+            message: "operationIds was changed",
+          });
+        }
+      },
+    );
+  },
+});
+
+const parameterCase = new OperationRule({
+  name: "operation parameters snake case",
+  docsLink: links.standards.parameterNamesPathComponents,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.pathParameter.added(
+      "use the correct case",
+      (pathParameter) => {
+        const name = pathParameter.value.name;
+        if (snakeCase(name) !== name) {
+          throw new RuleError({
+            message: `expected parameter name ${name} to be snake case`,
+          });
+        }
+      },
+    );
+
+    operationAssertions.queryParameter.added(
+      "use the correct case",
+      (queryParameter) => {
+        const name = queryParameter.value.name;
+        if (snakeCase(name) !== name) {
+          throw new RuleError({
+            message: `expected parameter name ${name} to be snake case`,
+          });
+        }
+      },
+    );
+  },
+});
+
+const noPutHttpMethod = new OperationRule({
+  name: "no put method",
+  rule: (operationAssertions) => [
+    operationAssertions.added("not use put method", (operation) => {
+      if (operation.method === "put") {
+        throw new RuleError({
+          message: "put is not allowed in JSON:API",
+        });
+      }
+    }),
+  ],
+});
+
+const preventOperationRemoval = new OperationRule({
+  name: "prevent operation removal",
+  docsLink: links.versioning.breakingChanges,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.removed("not be allowed", () => {
+      throw new RuleError({
+        message: "expected operation to be present",
+      });
+    });
+  },
+});
+
+const requireVersionParameter = new OperationRule({
+  name: "require version parameter",
+  docsLink: links.versioning.versionParameter,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.requirement.hasQueryParameterMatching({
+      name: "version",
+    });
+  },
+});
+
+const tenantFormatting = new OperationRule({
+  name: "tenant formatting",
+  docsLink: links.standards.orgAndGroupTenantResources,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.pathParameter.requirement(
+      "use UUID for org_id or group_id",
+      (parameter) => {
+        const name = parameter.value.name;
+        if (name === "group_id" || name === "org_id") {
+          if (!parameter.value.schema) {
+            throw new RuleError({
+              message: "expected parameter to have a schema",
+            });
+          }
+
+          if (
+            !("$ref" in parameter.value.schema) &&
+            parameter.value.schema.format !== "uuid"
+          ) {
+            throw new RuleError({
+              message: "expected parameter to use format uuid",
+            });
+          }
+        }
+      },
+    );
+  },
+});
+
+const pathElementCasing = new OperationRule({
+  name: "path element casing",
+  docsLink: links.standards.parameterNamesPathComponents,
+  rule: (operationAssertions) => {
+    operationAssertions.requirement(
+      "use the right casing for path elements",
+      (operation) => {
+        const parts = operation.path.replace(/[?].*/, "").split(/[/]/);
+        const invalid = parts
+          // Filter out empty string (leading path) and params (different rule)
+          .filter((part) => part.length > 0 && !part.match(/^[{].*[}]/))
+          .filter((part) => snakeCase(part) !== part);
+        if (invalid.length !== 0) {
+          throw new RuleError({
+            message: `expected ${operation.path} to support the correct casing`,
+          });
+        }
+      },
+    );
+  },
+});
+
+const preventAddingRequiredQueryParameters = new OperationRule({
+  name: "prevent adding required query parameter",
+  docsLink: links.versioning.breakingChanges,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability) &&
+    ruleContext.operation.change !== "added",
+  rule: (operationAssertions) => {
+    operationAssertions.queryParameter.added("not be required", (parameter) => {
+      if (parameter.value.required) {
+        throw new RuleError({
+          message: `expected request query parameter ${parameter.value.name} to not be required`,
+        });
+      }
+    });
+  },
+});
+
+const preventChangingOptionalToRequiredQueryParameters = new OperationRule({
+  name: "prevent changing optional query parameter to required",
+  docsLink: links.versioning.breakingChanges,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.queryParameter.changed(
+      "not be required",
+      (before, after) => {
+        if (!before.value.required && after.value.required) {
+          throw new RuleError({
+            message: `expected request query parameter ${after.value.required} to not change from optional to required`,
+          });
+        }
+      },
+    );
+  },
+});
+
+const preventRemovingStatusCodes = new ResponseRule({
+  name: "prevent removing status codes",
+  docsLink: links.versioning.breakingChanges,
+
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (responseAssertions) => {
+    responseAssertions.removed("not be removed", () => {
+      throw new RuleError({
+        message: "must not remove response status code",
+      });
+    });
+  },
+});
+
+const preventChangingParameterDefaultValue = new OperationRule({
+  name: "prevent changing parameter default value",
+  docsLink: links.versioning.breakingChanges,
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    operationAssertions.queryParameter.changed(
+      "not change the default value",
+      (before, after) => {
+        const beforeSchema = (before.value.schema ||
+          {}) as OpenAPIV3.SchemaObject;
+        const afterSchema = (after.value.schema ||
+          {}) as OpenAPIV3.SchemaObject;
+
+        if (beforeSchema.default !== afterSchema.default) {
+          throw new RuleError({
+            message: `default schema was changed from ${beforeSchema.default} to ${afterSchema.default}`,
+          });
+        }
+      },
+    );
+  },
+});
+
+const preventChangingParameterSchemaFormat = new OperationRule({
+  name: "prevent changing parameter schema format",
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    const parameterAssertion = (before, after) => {
+      const beforeSchema = (before.value.schema ||
+        {}) as OpenAPIV3.SchemaObject;
+      const afterSchema = (after.value.schema || {}) as OpenAPIV3.SchemaObject;
+
+      if (beforeSchema.format !== afterSchema.format) {
+        throw new RuleError({
+          message: `schema format was changed from ${beforeSchema.format} to ${afterSchema.format}`,
+        });
+      }
+    };
+
+    operationAssertions.queryParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+    operationAssertions.headerParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+    operationAssertions.pathParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+  },
+});
+
+const preventChangingParameterSchemaPattern = new OperationRule({
+  name: "prevent changing parameter schema pattern",
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    const parameterAssertion = (before, after) => {
+      const beforeSchema = (before.value.schema ||
+        {}) as OpenAPIV3.SchemaObject;
+      const afterSchema = (after.value.schema || {}) as OpenAPIV3.SchemaObject;
+
+      if (beforeSchema.pattern !== afterSchema.pattern) {
+        throw new RuleError({
+          message: `schema pattern was changed from ${beforeSchema.pattern} to ${afterSchema.pattern}`,
+        });
+      }
+    };
+
+    operationAssertions.queryParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+    operationAssertions.headerParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+    operationAssertions.pathParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+  },
+});
+
+const preventChangingParameterSchemaType = new OperationRule({
+  name: "prevent changing parameter schema type",
+  matches: (operation, ruleContext) =>
+    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
+  rule: (operationAssertions) => {
+    const parameterAssertion = (before, after) => {
+      const beforeSchema = (before.value.schema ||
+        {}) as OpenAPIV3.SchemaObject;
+      const afterSchema = (after.value.schema || {}) as OpenAPIV3.SchemaObject;
+
+      if (beforeSchema.type !== afterSchema.type) {
+        throw new RuleError({
+          message: `schema type was changed from ${beforeSchema.type} to ${afterSchema.type}`,
+        });
+      }
+    };
+
+    operationAssertions.queryParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+    operationAssertions.headerParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+    operationAssertions.pathParameter.changed(
+      "not change the schema format",
+      parameterAssertion,
+    );
+  },
+});
+
+export const operationRules = new Ruleset({
+  name: "operation rules",
+  rules: [
+    operationId,
+    operationIdSet,
+    tags,
+    summary,
+    consistentOperationIds,
+    parameterCase,
+    noPutHttpMethod,
+    preventOperationRemoval,
+    requireVersionParameter,
+    tenantFormatting,
+    pathElementCasing,
+    preventAddingRequiredQueryParameters,
+    preventChangingOptionalToRequiredQueryParameters,
+    preventRemovingStatusCodes,
+    preventChangingParameterDefaultValue,
+    preventChangingParameterSchemaFormat,
+    preventChangingParameterSchemaPattern,
+    preventChangingParameterSchemaType,
+  ],
+});


### PR DESCRIPTION
Migrating the [operation rules](https://github.com/snyk/sweater-comb/blob/main/src/rulesets/operation.ts) in this PR.

This should be the last one to migrate. There's a few things we should do before making the switch over to the new rule running API:
- I've got a change coming from optic to provide a way to write custom matcher error messages. Doing a `operationAssertions.requirement.matches({ summary: Matchers.string })` assertion will just show the operation and expected shape, but in this case, you can just add an error message that says operations must have a summary.
- Connect up the existing e2e tests to the new ruleset tests (there appears to be two, [internal JS tests](https://github.com/snyk/sweater-comb/blob/main/src/rulesets/tests/end-end.test.ts) and [full CLI tests](https://github.com/snyk/sweater-comb/tree/main/end-end-tests) - we'll want to run both, and spot check some of the error messages + runs to see if there's anything we want to address here