### PR TITLE
chore: update experimental stability definition, formatting fixes

### DIFF
--- a/docs/principles/version.md
+++ b/docs/principles/version.md
@@ -46,14 +46,15 @@ Stability levels guarantee a certain level of consistency in the API contract, a
 In increasing order of stability, from least to most stable, these are:
 
 - `wip`
-    - The resource is just getting started and functionally may be in a broken or incomplete state with regard to its OpenAPI spec. WIP-versioned resources should not be made publicly accessible.
+    - The resource is just getting started and may be in a broken or incomplete state with regard to its OpenAPI spec. WIP-versioned resources are not made publicly accessible.
 - `experimental`
-    - The resource version is a functional implementation of its OpenAPI spec.
-    - It will be available for at least **30 days** after a subsequent resource version *of equal or greater stability* is published, after which it may be removed.
-    - During its availability, it must not be revised with incompatible and breaking changes.
+    - The resource version is a functionally complete implementation of its OpenAPI spec. Experimental versions may be publicly accessible.
+    - There are NO guarantees on the stability or future availability of the API version.
+      - Breaking changes in the API may be introduced at any time.
+      - The API version may sunset at any time.
     - May be distributed as a limited tech preview.
 - `beta`
-    - The resource version may be regarded as a candidate for general availability.
+    - The resource version is being evaluated as a candidate for general availability by partners and customers.
     - It will be available for at least **90 days** after a subsequent resource version *of equal or greater stability* (`beta` or `ga`) is published, after which it may be removed.
     - During its availability, it must not be revised with incompatible and breaking changes.
     - It may be revised with backwards-compatible, additive changes.
@@ -62,6 +63,10 @@ In increasing order of stability, from least to most stable, these are:
     - It will be available for at least **180 days** after a subsequent `ga` resource version is published, after which it may be removed.
     - During its availability, it must not be revised with incompatible and breaking changes.
     - It may be revised with backwards-compatible, additive changes.
+
+`experimental` is where new API features are incubated. Experiments are unlisted in official product documentation, though they may be publicly routed. They're a place to try new things, stress test, invite early feedback, and iterate. Experiments are a temporary draft of an API, so they are considered deprecated upon release. After 90 days, experimental versions automatically sunset. To keep an experiment going, iterate with a new release version or promote it to `beta`.
+
+`beta` and `ga` are held to stricter requirements, with SLA guarantees on API stability, availability and maintenance.
 
 ### Promoting stability of a resource over time
 

--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -80,9 +80,7 @@ Operation IDs must use **camel case** names. Example:
 operationId: getFoo
 ```
 
-#### How to name operations
-
-##### Prefix the operation ID with the action being performed
+#### Prefix the operation ID with the action being performed
 
 - GET becomes `get` for a single resource (by unique ID)
 - GET becomes `list` for multiple resources (pagination and filtering)
@@ -90,7 +88,7 @@ operationId: getFoo
 - PATCH becomes `update`
 - DELETE becomes `delete`
 
-##### Suffix the operation ID with the resource
+#### Suffix the operation ID with the name of the resource
 
 Use the singular form if the operation operates on a single resource, plural if it operates on a collection operation.
 
@@ -101,9 +99,9 @@ Examples:
 - `updateOtherThing` (update one)
 - `deleteThings` (bulk delete)
 
-##### Optionally, suffix the resource with any tenancy
+#### Suffix the resource with tenancy if needed
 
-If there are multiple ways to address the resource by tenancy, differentiate these as a resource name suffix.
+If there are operations which allow addressing the resource by multiple tenancies (a containing resource), differentiate these as a "by resource" name suffix.
 
 Example: `getFooByOrg`, `deleteProjectByGroup`, etc.
 
@@ -111,8 +109,8 @@ Example: `getFooByOrg`, `deleteProjectByGroup`, etc.
 
 ```json
 headers:
-    snyk-requested-version: 2021-08-21~beta
-    snyk-resolved-version: 2021-08-12~beta
+    snyk-requested-version: "2021-08-21~beta"
+    snyk-resolved-version: "2021-08-12~beta"
 ```
 
 [Header field names are case insensitive](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2). Snyk v3 API specs must use kebab case for consistency. All non-standard headers that are unique to Snyk must begin with `snyk-` (e.g. `snyk-requested-version`).


### PR DESCRIPTION
We've decided that experiments should be unstable enough to iterate on
ideas, especially when we need to explore new conceptual territory.
    
Fixes #261.

Drive-by: Improve wording on tenancy.