### PR TITLE
fix: regression in operation naming rules for experimental stability

### DIFF
--- a/end-end-tests/api-standards/resources/repos/2022-04-04/spec.yaml
+++ b/end-end-tests/api-standards/resources/repos/2022-04-04/spec.yaml
@@ -1,0 +1,360 @@
+openapi: 3.0.3
+x-snyk-api-stability: experimental
+info:
+  title: Repo Resource
+  version: 3.0.0
+  x-plural-name: repos
+  x-singular-name: repo
+servers:
+  - url: /rest
+    description: go-service-sample
+tags:
+  - name: Repo
+    description: A repository
+paths:
+  /orgs/{orgId}/repos/{repoId}:
+    get:
+      summary: Get a repository
+      description: Get a repository
+      operationId: getRepo
+      tags:
+        - Repo
+      x-cerberus:
+        authorization:
+          resource:
+            pathId: 'orgId'
+            type: 'org'
+            entitlements:
+              - api
+            permissions:
+              - read
+      parameters:
+        - $ref: '#/components/x-rest-common/parameters/Version'
+        - $ref: '#/components/parameters/OrgId'
+        - $ref: '#/components/parameters/RepoId'
+      responses:
+        '200':
+          description: Returns a repository
+          headers:
+            snyk-version-requested:
+              $ref: >-
+                #/components/x-rest-common/headers/VersionRequestedResponseHeader
+            snyk-version-served:
+              $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader'
+            snyk-request-id:
+              $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader'
+            snyk-version-lifecycle-stage:
+              $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader'
+            deprecation:
+              $ref: '#/components/x-rest-common/headers/DeprecationHeader'
+            sunset:
+              $ref: '#/components/x-rest-common/headers/SunsetHeader'
+          content:
+            application/vnd.api+json:
+              schema:
+                properties:
+                  jsonapi:
+                    $ref: '#/components/x-rest-common/schemas/JsonApi'
+                  data:
+                    type: object
+                    description: repo resource object
+                    required:
+                      - id
+                      - type
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+                      type:
+                        $ref: '#/components/x-rest-common/schemas/Types'
+                      attributes:
+                        $ref: '#/components/schemas/RepoAttributes'
+                      relationships:
+                        $ref: '#/components/schemas/RepoRelationships'
+                    additionalProperties: false
+                  links:
+                    $ref: '#/components/x-rest-common/schemas/PaginatedLinks'
+        '400':
+          $ref: '#/components/x-rest-common/responses/400'
+        '401':
+          $ref: '#/components/x-rest-common/responses/401'
+        '403':
+          $ref: '#/components/x-rest-common/responses/403'
+        '404':
+          $ref: '#/components/x-rest-common/responses/404'
+        '409':
+          $ref: '#/components/x-rest-common/responses/409'
+        '500':
+          $ref: '#/components/x-rest-common/responses/500'
+    delete:
+      summary: Delete a repository
+      description: Delete a repository
+      operationId: deleteRepo
+      tags:
+        - Repo
+      x-cerberus:
+        authorization:
+          resource:
+            pathId: 'orgId'
+            type: 'org'
+            entitlements:
+              - api
+            permissions:
+              - delete
+      parameters:
+        - $ref: '#/components/x-rest-common/parameters/Version'
+        - $ref: '#/components/parameters/OrgId'
+        - $ref: '#/components/parameters/RepoId'
+      responses:
+        '204':
+          $ref: '#/components/x-rest-common/responses/204'
+        '400':
+          $ref: '#/components/x-rest-common/responses/400'
+        '401':
+          $ref: '#/components/x-rest-common/responses/401'
+        '403':
+          $ref: '#/components/x-rest-common/responses/403'
+        '404':
+          $ref: '#/components/x-rest-common/responses/404'
+        '409':
+          $ref: '#/components/x-rest-common/responses/409'
+        '500':
+          $ref: '#/components/x-rest-common/responses/500'
+  /orgs/{orgId}/repos:
+    get:
+      summary: List repositories
+      description: List repositories
+      operationId: listRepo
+      tags:
+        - Repo
+      x-cerberus:
+        authorization:
+          resource:
+            pathId: 'orgId'
+            type: 'org'
+            entitlements:
+              - api
+            permissions:
+              - read
+      parameters:
+        - $ref: '#/components/x-rest-common/parameters/Version'
+        - $ref: '#/components/parameters/OrgId'
+        - $ref: '#/components/x-rest-common/parameters/StartingAfter'
+        - $ref: '#/components/x-rest-common/parameters/EndingBefore'
+        - $ref: '#/components/x-rest-common/parameters/Limit'
+      responses:
+        '200':
+          description: Returns a list of repositories
+          headers:
+            snyk-version-requested:
+              $ref: >-
+                #/components/x-rest-common/headers/VersionRequestedResponseHeader
+            snyk-version-served:
+              $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader'
+            snyk-request-id:
+              $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader'
+            snyk-version-lifecycle-stage:
+              $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader'
+            deprecation:
+              $ref: '#/components/x-rest-common/headers/DeprecationHeader'
+            sunset:
+              $ref: '#/components/x-rest-common/headers/SunsetHeader'
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  jsonapi:
+                    $ref: '#/components/x-rest-common/schemas/JsonApi'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - type
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+                        type:
+                          $ref: '#/components/x-rest-common/schemas/Types'
+                        attributes:
+                          $ref: '#/components/schemas/RepoAttributes'
+                        relationships:
+                          $ref: '#/components/schemas/RepoRelationships'
+                  links:
+                    $ref: '#/components/x-rest-common/schemas/PaginatedLinks'
+        '400':
+          $ref: '#/components/x-rest-common/responses/400'
+        '401':
+          $ref: '#/components/x-rest-common/responses/401'
+        '403':
+          $ref: '#/components/x-rest-common/responses/403'
+        '404':
+          $ref: '#/components/x-rest-common/responses/404'
+        '409':
+          $ref: '#/components/x-rest-common/responses/409'
+        '500':
+          $ref: '#/components/x-rest-common/responses/500'
+    post:
+      summary: Create a new repository
+      description: Create a new repository
+      operationId: createRepo
+      tags:
+        - Repo
+      x-cerberus:
+        authorization:
+          resource:
+            pathId: 'orgId'
+            type: 'org'
+            entitlements:
+              - api
+            permissions:
+              - create
+      parameters:
+        - $ref: '#/components/x-rest-common/parameters/Version'
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                attributes:
+                  $ref: '#/components/schemas/RepoCreateAttributes'
+              additionalProperties: false
+      responses:
+        '201':
+          description: Created repository successfully
+          headers:
+            snyk-version-requested:
+              $ref: >-
+                #/components/x-rest-common/headers/VersionRequestedResponseHeader
+            snyk-version-served:
+              $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader'
+            snyk-request-id:
+              $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader'
+            snyk-version-lifecycle-stage:
+              $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader'
+            deprecation:
+              $ref: '#/components/x-rest-common/headers/DeprecationHeader'
+            sunset:
+              $ref: '#/components/x-rest-common/headers/SunsetHeader'
+            location:
+              $ref: '#/components/x-rest-common/headers/LocationHeader'
+          content:
+            application/vnd.api+json:
+              schema:
+                properties:
+                  jsonapi:
+                    $ref: '#/components/x-rest-common/schemas/JsonApi'
+                  data:
+                    type: object
+                    description: repo resource object
+                    required:
+                      - id
+                      - type
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+                      type:
+                        $ref: '#/components/x-rest-common/schemas/Types'
+                      attributes:
+                        $ref: '#/components/schemas/RepoAttributes'
+                      relationships:
+                        $ref: '#/components/schemas/RepoRelationships'
+                    additionalProperties: false
+                  links:
+                    $ref: '#/components/x-rest-common/schemas/PaginatedLinks'
+        '400':
+          $ref: '#/components/x-rest-common/responses/400'
+        '401':
+          $ref: '#/components/x-rest-common/responses/401'
+        '403':
+          $ref: '#/components/x-rest-common/responses/403'
+        '404':
+          $ref: '#/components/x-rest-common/responses/404'
+        '409':
+          $ref: '#/components/x-rest-common/responses/409'
+        '500':
+          $ref: '#/components/x-rest-common/responses/500'
+components:
+  schemas:
+    RepoAttributes:
+      type: object
+      properties:
+        created:
+          type: string
+          format: date-time
+        name:
+          type: string
+        link:
+          type: string
+          format: uri
+        type:
+          type: string
+          enum:
+            - private
+            - public
+      required:
+        - name
+        - type
+      example:
+        created: '2022-01-14T00:23:50Z'
+        name: Snyk
+        link: https://app.snyk.io
+        type: private
+    RepoRelationships:
+      type: object
+      properties: {}
+      additionalProperties: false
+    RepoCreateAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+        link:
+          type: string
+          format: uri
+        type:
+          type: string
+          enum:
+            - private
+            - public
+      required:
+        - name
+        - type
+      example:
+        created: '2022-01-14T00:23:50Z'
+        name: Snyk
+        link: https://app.snyk.io
+        type: private
+  x-rest-common:
+    $ref: >-
+      https://raw.githubusercontent.com/snyk/sweater-comb/common-model-v1/components/common.yaml
+  parameters:
+    RepoId:
+      name: repoId
+      in: path
+      required: true
+      description: Repository identifier
+      schema:
+        type: string
+        format: uuid
+    OrgId:
+      name: orgId
+      in: path
+      required: true
+      description: Organization identifier
+      schema:
+        type: string
+        format: uuid

--- a/end-end-tests/api-standards/resources/thing/2021-11-10/001-fail-operationid-change-beta.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/001-fail-operationid-change-beta.yaml
@@ -1,0 +1,233 @@
+# 001-fail-operationid-change-beta.yaml
+# Changing a path request method's operationId is also considered a breaking change
+openapi: 3.0.3
+x-snyk-api-stability: beta
+info:
+  title: v3
+  version: 3.0.0
+servers:
+  - url: https://api.snyk.io/v3
+    description: Public Snyk API
+tags:
+  - name: Thing
+    description: Short description of what Thing represents
+paths:
+  /orgs/{org_id}/thing:
+    post:
+      summary: Create a new thing
+      description: Create a new thing
+      operationId: makeThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: '#/components/x-rest-common/parameters/Version' }
+        - { $ref: '#/components/parameters/OrgId' }
+      responses:
+        '201':
+          description: Created thing successfully
+          headers:
+            snyk-version-requested: { $ref: '#/components/x-rest-common/headers/VersionRequestedResponseHeader' }
+            snyk-version-served: { $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader' }
+            snyk-request-id: { $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader' }
+            snyk-version-lifecycle-stage: { $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader' }
+            deprecation: { $ref: '#/components/x-rest-common/headers/DeprecationHeader' }
+            sunset: { $ref: '#/components/x-rest-common/headers/SunsetHeader' }
+            location: { $ref: '#/components/x-rest-common/headers/LocationHeader' }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: '#/components/schemas/ThingResourceResponse' }
+        '400': { $ref: '#/components/x-rest-common/responses/400' }
+        '401': { $ref: '#/components/x-rest-common/responses/401' }
+        '403': { $ref: '#/components/x-rest-common/responses/403' }
+        '404': { $ref: '#/components/x-rest-common/responses/404' }
+        '409': { $ref: '#/components/x-rest-common/responses/409' }
+        '500': { $ref: '#/components/x-rest-common/responses/500' }
+    get:
+      summary: List instances of thing
+      description: List instances of thing
+      operationId: listThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: '#/components/x-rest-common/parameters/Version' }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/x-rest-common/parameters/StartingAfter" }
+        - { $ref: "#/components/x-rest-common/parameters/EndingBefore" }
+        - { $ref: "#/components/x-rest-common/parameters/Limit" }
+      responses:
+        '200':
+          description: Returns a list of thing instances
+          headers:
+            snyk-version-requested: { $ref: '#/components/x-rest-common/headers/VersionRequestedResponseHeader' }
+            snyk-version-served: { $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader' }
+            snyk-request-id: { $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader' }
+            snyk-version-lifecycle-stage: { $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader' }
+            deprecation: { $ref: '#/components/x-rest-common/headers/DeprecationHeader' }
+            sunset: { $ref: '#/components/x-rest-common/headers/SunsetHeader' }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: '#/components/schemas/ThingCollectionResponse' }
+        '400': { $ref: '#/components/x-rest-common/responses/400' }
+        '401': { $ref: '#/components/x-rest-common/responses/401' }
+        '403': { $ref: '#/components/x-rest-common/responses/403' }
+        '404': { $ref: '#/components/x-rest-common/responses/404' }
+        '500': { $ref: '#/components/x-rest-common/responses/500' }
+  /orgs/{org_id}/thing/{thing_id}:
+    get:
+      summary: Get an instance of thing
+      description: Get an instance of thing
+      operationId: getThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: '#/components/x-rest-common/parameters/Version' }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: '#/components/parameters/ThingId' }
+      responses:
+        '200':
+          description: Returns an instance of thing
+          headers:
+            snyk-version-requested: { $ref: '#/components/x-rest-common/headers/VersionRequestedResponseHeader' }
+            snyk-version-served: { $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader' }
+            snyk-request-id: { $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader' }
+            snyk-version-lifecycle-stage: { $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader' }
+            deprecation: { $ref: '#/components/x-rest-common/headers/DeprecationHeader' }
+            sunset: { $ref: '#/components/x-rest-common/headers/SunsetHeader' }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: '#/components/schemas/ThingResourceResponse' }
+        '400': { $ref: '#/components/x-rest-common/responses/400' }
+        '401': { $ref: '#/components/x-rest-common/responses/401' }
+        '403': { $ref: '#/components/x-rest-common/responses/403' }
+        '404': { $ref: '#/components/x-rest-common/responses/404' }
+        '500': { $ref: '#/components/x-rest-common/responses/500' }
+    patch:
+      summary: Update an instance of thing
+      description: Update an instance of thing
+      operationId: updateThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: '#/components/x-rest-common/parameters/Version' }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: '#/components/parameters/ThingId' }
+      responses:
+        '200':
+          description: Instance of thing is updated.
+          headers:
+            snyk-version-requested: { $ref: '#/components/x-rest-common/headers/VersionRequestedResponseHeader' }
+            snyk-version-served: { $ref: '#/components/x-rest-common/headers/VersionServedResponseHeader' }
+            snyk-request-id: { $ref: '#/components/x-rest-common/headers/RequestIdResponseHeader' }
+            snyk-version-lifecycle-stage: { $ref: '#/components/x-rest-common/headers/VersionStageResponseHeader' }
+            deprecation: { $ref: '#/components/x-rest-common/headers/DeprecationHeader' }
+            sunset: { $ref: '#/components/x-rest-common/headers/SunsetHeader' }
+          content:
+            application/vnd.api+json:
+              schema: { $ref: '#/components/schemas/ThingResourceResponse' }
+        '204': { $ref: '#/components/x-rest-common/responses/204' }
+        '400': { $ref: '#/components/x-rest-common/responses/400' }
+        '401': { $ref: '#/components/x-rest-common/responses/401' }
+        '403': { $ref: '#/components/x-rest-common/responses/403' }
+        '404': { $ref: '#/components/x-rest-common/responses/404' }
+        '409': { $ref: '#/components/x-rest-common/responses/409' }
+        '500': { $ref: '#/components/x-rest-common/responses/500' }
+    delete:
+      summary: Delete an instance of thing
+      description: Delete an instance of thing
+      operationId: deleteThing
+      tags:
+        - Thing
+      parameters:
+        - { $ref: '#/components/x-rest-common/parameters/Version' }
+        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: '#/components/parameters/ThingId' }
+      responses:
+        '204': { $ref: '#/components/x-rest-common/responses/204' }
+        '400': { $ref: '#/components/x-rest-common/responses/400' }
+        '401': { $ref: '#/components/x-rest-common/responses/401' }
+        '403': { $ref: '#/components/x-rest-common/responses/403' }
+        '404': { $ref: '#/components/x-rest-common/responses/404' }
+        '409': { $ref: '#/components/x-rest-common/responses/409' }
+        '500': { $ref: '#/components/x-rest-common/responses/500' }
+components:
+  x-rest-common:
+    $ref: '../../../../../components/common.yaml'
+  parameters:
+    OrgId:
+      name: org_id
+      in: path
+      required: true
+      description: Org ID
+      schema:
+        type: string
+        format: uuid
+    ThingId:
+      name: thing_id
+      in: path
+      required: true
+      description: Unique identifier for thing instances
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    ThingResourceResponse:
+      type: object
+      description: Response containing a single thing resource object
+      properties:
+        jsonapi: { $ref: '#/components/x-rest-common/schemas/JsonApi' }
+        data: { $ref: '#/components/schemas/ThingResource' }
+        links: { $ref: '#/components/x-rest-common/schemas/SelfLink' }
+
+    ThingCollectionResponse:
+      type: object
+      description: Response containing a collection of thing resource objects
+      properties:
+        jsonapi: { $ref: '#/components/x-rest-common/schemas/JsonApi' }
+        data: { $ref: '#/components/schemas/ThingCollection' }
+        links: { $ref: '#/components/x-rest-common/schemas/PaginatedLinks' }
+
+    ThingResource:
+      type: object
+      description: thing resource object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+        type: { $ref: '#/components/x-rest-common/schemas/Types' }
+        attributes: { $ref: '#/components/schemas/ThingAttributes' }
+        relationships: { $ref: '#/components/schemas/ThingRelationships' }
+      additionalProperties: false
+
+    ThingRelationships:
+      type: object
+      properties:
+        example: { $ref: '#/components/x-rest-common/schemas/Relationship' }
+      additionalProperties: false
+
+    ThingCollection:
+      type: array
+      items: { $ref: '#/components/schemas/ThingResource' }
+
+    ThingAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of this instance of thing.
+          example: thing
+        created:
+          type: string
+          description: Timestamp when this instance of thing was created.
+          format: date-time
+          example: '2021-10-05T13:23:17Z'
+        updated:
+          type: string
+          description: Timestamp when this instance of thing was last updated.
+          format: date-time
+          example: '2021-10-05T13:25:29Z'
+        description:
+          type: string
+          description: User-friendly description of this instance of thing.
+          example: "This is a thing named thing."
+      additionalProperties: false

--- a/end-end-tests/api-standards/resources/thing/2021-11-10/001-fail-operationid-change.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/001-fail-operationid-change.yaml
@@ -1,4 +1,4 @@
-# 001-fail-operationid-change.yaml
+# 001-fail-operationid-change-beta.yaml
 # Changing a path request method's operationId is also considered a breaking change
 openapi: 3.0.3
 x-snyk-api-stability: experimental

--- a/end-end-tests/api-standards/test.bash
+++ b/end-end-tests/api-standards/test.bash
@@ -63,11 +63,6 @@ ${COMPARE} \
     --context "${CONTEXT}"
 assert_ok
 ${COMPARE} \
-    --from $HERE/resources/thing/2021-11-10/000-baseline.yaml \
-    --to $HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml \
-    --context "${CONTEXT}"
-assert_ok
-${COMPARE} \
     --from $HERE/resources/thing/2021-11-10/002-ok-add-operation.yaml \
     --to $HERE/resources/thing/2021-11-10/003-ok-type-change.yaml \
     --context "${CONTEXT}"
@@ -81,9 +76,19 @@ ${COMPARE} \
     --context "${CONTEXT}"
 assert_err
 
+${COMPARE} \
+    --to $HERE/resources/thing/2021-11-10/001-fail-operationid-change.yaml \
+    --context "${CONTEXT}"
+assert_err
+
 ## breaking changes not allowed at beta
 
 ### cannot make a breaking type change in beta
+${COMPARE} \
+    --from $HERE/resources/thing/2021-11-10/000-baseline-beta.yaml \
+    --to $HERE/resources/thing/2021-11-10/001-fail-operationid-change-beta.yaml \
+    --context "${CONTEXT}"
+assert_err
 ${COMPARE} \
     --from $HERE/resources/thing/2021-11-10/000-baseline-beta.yaml \
     --to $HERE/resources/thing/2021-11-10/001-fail-type-change-beta.yaml \

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/operation-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/operation-rules.test.ts.snap
@@ -2240,7 +2240,7 @@ Array [
 ]
 `;
 
-exports[`operation parameters names fails if the case is not correct 1`] = `
+exports[`operation parameters names fails if the case is not correct, stability beta 1`] = `
 Array [
   Object {
     "change": Object {
@@ -2648,7 +2648,1639 @@ Array [
 ]
 `;
 
-exports[`operation parameters names passes if the case is correct 1`] = `
+exports[`operation parameters names fails if the case is not correct, stability experimental 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "pathParameter",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "pathParameter",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "pathParameter",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": "expected parameter name pathParameter to be snake case",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": false,
+    "received": undefined,
+    "where": "added path parameter: pathParameter in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "pathParameter",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "pathParameter",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "pathParameter",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: pathParameter in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "declare a resource name at the path root",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource path cannot begin with a parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+]
+`;
+
+exports[`operation parameters names fails if the case is not correct, stability ga 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "pathParameter",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "pathParameter",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "pathParameter",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": "expected parameter name pathParameter to be snake case",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": false,
+    "received": undefined,
+    "where": "added path parameter: pathParameter in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "pathParameter",
+          },
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "pathParameter",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "pathParameter",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: pathParameter in operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{pathParameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{pathParameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{pathParameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "declare a resource name at the path root",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource path cannot begin with a parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{pathParameter}",
+  },
+]
+`;
+
+exports[`operation parameters names passes if the case is correct, stability beta 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "path_parameter",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "path_parameter",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "path_parameter",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added path parameter: path_parameter in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "path_parameter",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "path_parameter",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "path_parameter",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: path_parameter in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "declare a resource name at the path root",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource path cannot begin with a parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+]
+`;
+
+exports[`operation parameters names passes if the case is correct, stability experimental 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "path_parameter",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "path_parameter",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "path_parameter",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added path parameter: path_parameter in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "path_parameter",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "path",
+          "path_parameter",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "path_parameter",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: path_parameter in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example/{path_parameter}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "declare a resource name at the path root",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource path cannot begin with a parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example/{path_parameter}",
+  },
+]
+`;
+
+exports[`operation parameters names passes if the case is correct, stability ga 1`] = `
 Array [
   Object {
     "change": Object {
@@ -3119,6 +4751,114 @@ Array [
         ],
       },
     },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
     "condition": "use the right casing for path elements",
     "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
     "error": undefined,
@@ -3203,6 +4943,114 @@ Array [
     "isMust": true,
     "isShould": false,
     "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
     "passed": true,
     "received": undefined,
     "where": "requirement for operation: GET /example",
@@ -5898,7 +7746,673 @@ Array [
 ]
 `;
 
-exports[`passes when operation is set correctly 1`] = `
+exports[`passes when operation is set correctly, stability beta 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "declare a resource name at the path root",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource path cannot begin with a parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`passes when operation is set correctly, stability experimental 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id set",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1example/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "not use put method",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no put method",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "use the right casing for path elements",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "path element casing",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getExample",
+        "pathPattern": "/example",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "declare a resource name at the path root",
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "resource path cannot begin with a parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /example",
+  },
+]
+`;
+
+exports[`passes when operation is set correctly, stability ga 1`] = `
 Array [
   Object {
     "change": Object {
@@ -6235,6 +8749,43 @@ exports[`path requirements fails if the path root is a parameter 1`] = `
 Array [
   Object {
     "change": Object {
+      "added": Object {
+        "method": "get",
+        "operationId": "getAnything",
+        "pathPattern": "/{anything}/{goes}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get",
+        "kind": "operation",
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-ids",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation id",
+    "passed": true,
+    "received": undefined,
+    "where": "added operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
       "location": Object {
         "conceptualLocation": Object {
           "method": "get",
@@ -6268,6 +8819,192 @@ Array [
     "passed": true,
     "received": undefined,
     "where": "requirement for operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getAnything",
+        "pathPattern": "/{anything}/{goes}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#tags",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation tags",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getAnything",
+        "pathPattern": "/{anything}/{goes}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "match expected shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#operation-summary",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation summary",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "anything",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "anything",
+          },
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+          "parameters",
+          "path",
+          "anything",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added path parameter: anything in operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "path",
+        "name": "goes",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "goes",
+          },
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+          "parameters",
+          "path",
+          "goes",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get/parameters/2",
+        "kind": "path-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added path parameter: goes in operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "version",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "version",
+          },
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+          "parameters",
+          "query",
+          "version",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get/parameters/0",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#parameter-names-and-path-components",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: version in operation: GET /{anything}/{goes}",
   },
   Object {
     "change": Object {
@@ -6305,6 +9042,116 @@ Array [
     "passed": true,
     "received": undefined,
     "where": "added operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get",
+        "kind": "operation",
+      },
+      "value": Object {
+        "method": "get",
+        "operationId": "getAnything",
+        "pathPattern": "/{anything}/{goes}",
+        "summary": "this is an example",
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+    "condition": "have query parameter matching shape",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/version.md#how-are-versions-accessed-and-resolved-by-consumers",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require version parameter",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "anything",
+          },
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+          "parameters",
+          "path",
+          "anything",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get/parameters/1",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "anything",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: anything in operation: GET /{anything}/{goes}",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "path": "goes",
+          },
+          "method": "get",
+          "path": "/{anything}/{goes}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/{}/{}",
+          "get",
+          "parameters",
+          "path",
+          "goes",
+        ],
+        "jsonPath": "/paths/~1{anything}~1{goes}/get/parameters/2",
+        "kind": "path-parameter",
+      },
+      "value": Object {
+        "in": "path",
+        "name": "goes",
+      },
+    },
+    "condition": "use UUID for org_id or group_id",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#organization-and-group-tenants-for-resources",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "tenant formatting",
+    "passed": true,
+    "received": undefined,
+    "where": "requirement for path parameter: goes in operation: GET /{anything}/{goes}",
   },
   Object {
     "change": Object {

--- a/src/rulesets/rest/2022-05-25/__tests__/operation-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/operation-rules.test.ts
@@ -5,36 +5,46 @@ import { context } from "./fixtures";
 import { operationRules } from "../operation-rules";
 
 const baseJson = TestHelpers.createEmptySpec();
-test("passes when operation is set correctly", () => {
-  const ruleRunner = new RuleRunner([operationRules]);
-  const ruleInputs = {
-    ...TestHelpers.createRuleInputs(baseJson, {
-      ...baseJson,
-      paths: {
-        "/example": {
-          get: {
-            summary: "this is an example",
-            tags: ["example"],
-            parameters: [
-              {
-                name: "version",
-                in: "query",
-              },
-            ],
-            operationId: "getExample",
-            responses: {},
+
+test.each(["experimental", "beta", "ga"])(
+  "passes when operation is set correctly, stability %s",
+  (stability) => {
+    const ruleRunner = new RuleRunner([operationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, {
+        ...baseJson,
+        paths: {
+          "/example": {
+            get: {
+              summary: "this is an example",
+              tags: ["example"],
+              parameters: [
+                {
+                  name: "version",
+                  in: "query",
+                },
+              ],
+              operationId: "getExample",
+              responses: {},
+            },
           },
         },
+      } as OpenAPIV3.Document),
+      context: {
+        ...context,
+        changeVersion: {
+          ...context.changeVersion,
+          stability: stability,
+        },
       },
-    } as OpenAPIV3.Document),
-    context,
-  };
-  const results = ruleRunner.runRulesWithFacts(ruleInputs);
+    };
+    const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
-  expect(results.length).toBeGreaterThan(0);
-  expect(results.every((result) => result.passed)).toBe(true);
-  expect(results).toMatchSnapshot();
-});
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(true);
+    expect(results).toMatchSnapshot();
+  },
+);
 
 describe("operationId", () => {
   describe("missing", () => {
@@ -128,7 +138,13 @@ describe("operationId", () => {
             },
           },
         } as OpenAPIV3.Document),
-        context,
+        context: {
+          ...context,
+          changeVersion: {
+            ...context.changeVersion,
+            stability: "experimental",
+          },
+        },
       };
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
@@ -266,7 +282,13 @@ describe("operation metadata", () => {
           },
         },
       } as OpenAPIV3.Document),
-      context,
+      context: {
+        ...context,
+        changeVersion: {
+          ...context.changeVersion,
+          stability: "experimental",
+        },
+      },
     };
     const results = ruleRunner.runRulesWithFacts(ruleInputs);
 
@@ -311,73 +333,91 @@ describe("operation metadata", () => {
 
 describe("operation parameters", () => {
   describe("names", () => {
-    test("fails if the case is not correct", () => {
-      const ruleRunner = new RuleRunner([operationRules]);
-      const ruleInputs = {
-        ...TestHelpers.createRuleInputs(baseJson, {
-          ...baseJson,
-          paths: {
-            "/example/{pathParameter}": {
-              get: {
-                summary: "this is an example",
-                tags: ["example"],
-                parameters: [
-                  {
-                    name: "version",
-                    in: "query",
-                  },
-                  {
-                    name: "pathParameter",
-                    in: "path",
-                  },
-                ],
-                operationId: "getExample",
-                responses: {},
+    test.each(["experimental", "beta", "ga"])(
+      "fails if the case is not correct, stability %s",
+      (stability) => {
+        const ruleRunner = new RuleRunner([operationRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, {
+            ...baseJson,
+            paths: {
+              "/example/{pathParameter}": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                    {
+                      name: "pathParameter",
+                      in: "path",
+                    },
+                  ],
+                  operationId: "getExample",
+                  responses: {},
+                },
               },
             },
+          } as OpenAPIV3.Document),
+          context: {
+            ...context,
+            changeVersion: {
+              ...context.changeVersion,
+              stability: stability,
+            },
           },
-        } as OpenAPIV3.Document),
-        context,
-      };
-      const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(false);
-      expect(results).toMatchSnapshot();
-    });
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(false);
+        expect(results).toMatchSnapshot();
+      },
+    );
 
-    test("passes if the case is correct", () => {
-      const ruleRunner = new RuleRunner([operationRules]);
-      const ruleInputs = {
-        ...TestHelpers.createRuleInputs(baseJson, {
-          ...baseJson,
-          paths: {
-            "/example/{path_parameter}": {
-              get: {
-                summary: "this is an example",
-                tags: ["example"],
-                parameters: [
-                  {
-                    name: "version",
-                    in: "query",
-                  },
-                  {
-                    name: "path_parameter",
-                    in: "path",
-                  },
-                ],
-                operationId: "getExample",
-                responses: {},
+    test.each(["experimental", "beta", "ga"])(
+      "passes if the case is correct, stability %s",
+      (stability) => {
+        const ruleRunner = new RuleRunner([operationRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, {
+            ...baseJson,
+            paths: {
+              "/example/{path_parameter}": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                    {
+                      name: "path_parameter",
+                      in: "path",
+                    },
+                  ],
+                  operationId: "getExample",
+                  responses: {},
+                },
               },
             },
+          } as OpenAPIV3.Document),
+          context: {
+            ...context,
+            changeVersion: {
+              ...context.changeVersion,
+              stability: stability,
+            },
           },
-        } as OpenAPIV3.Document),
-        context,
-      };
-      const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(true);
-      expect(results).toMatchSnapshot();
-    });
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+        expect(results).toMatchSnapshot();
+      },
+    );
   });
   test("fails when adding a required query parameter", () => {
     const ruleRunner = new RuleRunner([operationRules]);

--- a/src/rulesets/rest/2022-05-25/operation-rules.ts
+++ b/src/rulesets/rest/2022-05-25/operation-rules.ts
@@ -17,10 +17,7 @@ const operationId = new OperationRule({
   matches: (operation, ruleContext) => {
     const changeDate = new Date(ruleContext.custom.changeVersion.date);
     const effectiveOnDate = new Date("2021-07-01");
-    return (
-      !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability) &&
-      changeDate > effectiveOnDate
-    );
+    return changeDate > effectiveOnDate;
   },
   rule: (operationAssertions) => {
     const prefixRegex = /^(get|create|list|update|delete)[A-Z]+.*/; // alternatively we could split at camelCase boundaries and assert on the first item
@@ -71,8 +68,6 @@ const operationIdSet = new OperationRule({
 const tags = new OperationRule({
   name: "operation tags",
   docsLink: links.standards.tags,
-  matches: (operation, ruleContext) =>
-    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (operationAssertions) => {
     operationAssertions.requirement.matches(
       {
@@ -88,8 +83,6 @@ const tags = new OperationRule({
 const summary = new OperationRule({
   name: "operation summary",
   docsLink: links.standards.operationSummary,
-  matches: (operation, ruleContext) =>
-    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (operationAssertions) => {
     operationAssertions.requirement.matches(
       {
@@ -124,8 +117,6 @@ const consistentOperationIds = new OperationRule({
 const parameterCase = new OperationRule({
   name: "operation parameters snake case",
   docsLink: links.standards.parameterNamesPathComponents,
-  matches: (operation, ruleContext) =>
-    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (operationAssertions) => {
     operationAssertions.pathParameter.added(
       "use the correct case",
@@ -183,8 +174,6 @@ const preventOperationRemoval = new OperationRule({
 const requireVersionParameter = new OperationRule({
   name: "require version parameter",
   docsLink: links.versioning.versionParameter,
-  matches: (operation, ruleContext) =>
-    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (operationAssertions) => {
     operationAssertions.requirement.hasQueryParameterMatching({
       name: "version",
@@ -195,8 +184,6 @@ const requireVersionParameter = new OperationRule({
 const tenantFormatting = new OperationRule({
   name: "tenant formatting",
   docsLink: links.standards.orgAndGroupTenantResources,
-  matches: (operation, ruleContext) =>
-    !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (operationAssertions) => {
     operationAssertions.pathParameter.requirement(
       "use UUID for org_id or group_id",

--- a/src/woollypully/__tests__/checker.test.ts
+++ b/src/woollypully/__tests__/checker.test.ts
@@ -64,7 +64,7 @@ describe("checker", () => {
     } catch (err: any) {
       fail(err.message);
     }
-  }, 15000);
+  }, 30000);
 
   test("fails if service is unavailable", async () => {
     (axios.default.create as jest.Mock).mockImplementation(() => ({


### PR DESCRIPTION
Some of the operation rules ported over to the new DSL were matching
!isBreakingChangeAllowed where they shouldn't have.

The result was a small window where operation ID and parameter naming
rules were not applied to experimental.

Technically this change introduces a tighter constraint which would
normally require a new REST API rules version.

However since this is a regression, which affected only experimental
(which is allowed breaking changes) and the regression was only released
for a small window of several days, the potential impact to fixing this
in-place should be small. Projects will need to conform to these rules
in order to promote to beta anyway.

In the event this change does disrupt API work, affected projects may
pin their Sweater Comb dependency version to buy themselves some time to
update their APIs.