### PR TITLE
fix: regression in batch POST rule

### DIFF
--- a/src/rulesets/rest/2022-05-25/__tests__/end-end.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/end-end.test.ts
@@ -156,6 +156,25 @@ describe("end-end-tests", () => {
     expect(results).toMatchSnapshot();
   });
 
+  it("passes valid bulk POST operation", async () => {
+    const results = await snapshotScenario(
+      undefined,
+      "000-batch-post.yaml",
+      resourceDate("thing", "2021-11-10"),
+      {
+        changeDate: "2021-11-11",
+        changeResource: "thing",
+        changeVersion: {
+          date: "2021-11-10",
+          stability: "experimental",
+        },
+        resourceVersions: {},
+      },
+    );
+    expect(results.every((result) => result.passed)).toBe(true);
+    expect(results).toMatchSnapshot();
+  });
+
   const rootOfRepo = path.resolve(path.join(__dirname, "../../../../../"));
 
   async function snapshotScenario(

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/status-code-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/status-code-rules.test.ts.snap
@@ -57,16 +57,16 @@ Array [
             "statusCode": "200",
           },
           "method": "post",
-          "path": "/api/users/{user_id}",
+          "path": "/api/users",
         },
         "conceptualPath": Array [
           "operations",
-          "/api/users/{}",
+          "/api/users",
           "post",
           "responses",
           "200",
         ],
-        "jsonPath": "/paths/~1api~1users~1{user_id}/post/responses/200",
+        "jsonPath": "/paths/~1api~1users/post/responses/200",
         "kind": "response",
       },
     },
@@ -79,7 +79,49 @@ Array [
     "name": "valid 2xx status codes for post",
     "passed": false,
     "received": undefined,
-    "where": "added response status code: 200 in operation: POST /api/users/{user_id}",
+    "where": "added response status code: 200 in operation: POST /api/users",
+  },
+]
+`;
+
+exports[`status code rules fails when an invalid batch post request is specified 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "i am not valid",
+        "statusCode": "204",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "204",
+          },
+          "method": "post",
+          "path": "/api/users/{user_id}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users/{}",
+          "post",
+          "responses",
+          "204",
+        ],
+        "jsonPath": "/paths/~1api~1users~1{user_id}/post/responses/204",
+        "kind": "response",
+      },
+    },
+    "condition": "support the correct 2xx status codes",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#status-codes",
+    "error": "expected POST response to only support 201, not 204",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid 2xx status codes for post",
+    "passed": false,
+    "received": undefined,
+    "where": "added response status code: 204 in operation: POST /api/users/{user_id}",
   },
 ]
 `;
@@ -164,6 +206,48 @@ Array [
     "passed": false,
     "received": undefined,
     "where": "added response status code: 200 in operation: POST /api/users/{user_id}",
+  },
+]
+`;
+
+exports[`status code rules passes for a valid batch post 204 code 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "got it",
+        "statusCode": "204",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "204",
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "responses",
+          "204",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/responses/204",
+        "kind": "response",
+      },
+    },
+    "condition": "support the correct 2xx status codes",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards.md#status-codes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid 2xx status codes for post",
+    "passed": true,
+    "received": undefined,
+    "where": "added response status code: 204 in operation: POST /api/users",
   },
 ]
 `;

--- a/src/rulesets/rest/2022-05-25/utils.ts
+++ b/src/rulesets/rest/2022-05-25/utils.ts
@@ -10,8 +10,14 @@ export const isBatchPostOperation = (requests) => {
   const request = requests.find(
     (request) => request.contentType === "application/vnd.api+json",
   );
-
-  return request ? request.value.flatSchema.type === "array" : false;
+  const requestSchema = request?.raw.schema;
+  if (!requestSchema) {
+    return false;
+  }
+  if (requestSchema.type !== "object") {
+    return false;
+  }
+  return requestSchema.properties?.data?.type === "array";
 };
 
 export const isBreakingChangeAllowed = (stability: string): boolean => {


### PR DESCRIPTION
This fixes a regression in the batch POST rule which allows a 204
response when the request body `data` property is an array.

When the rule was ported over, it seems to have changed to expect the
schema of the request body to be an array. It should instead be of the
form:

```
{
  data: [{id: "some-id", type: "some-type", ...}]
}
```