### PR TITLE
feat: woollypully service discovery from cerberus config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "fs-extra": "^10.0.0",
     "lodash.isequal": "^4.5.0",
     "nice-try": "^3.0.0",
+    "yaml": "^2.1.1",
     "yargs": "^17.4.1"
   },
   "bundledDependencies": [

--- a/src/woollypully/__tests__/checker.test.ts
+++ b/src/woollypully/__tests__/checker.test.ts
@@ -5,7 +5,7 @@ import * as axios from "axios";
 
 import { Checker } from "../checker";
 
-import { Config } from "../config";
+import { getConfig } from "../config";
 
 jest.mock("axios");
 jest.mock("@useoptic/openapi-io");
@@ -58,7 +58,7 @@ describe("checker", () => {
           Promise.resolve({ data: defaultSpecJson, status: 200 }),
         ),
     }));
-    const checker = new Checker(new Config());
+    const checker = new Checker(await getConfig());
     try {
       await checker.checkApis();
     } catch (err: any) {
@@ -72,7 +72,7 @@ describe("checker", () => {
         .fn()
         .mockImplementation(() => Promise.reject(new Error("bad wolf"))),
     }));
-    const checker = new Checker(new Config());
+    const checker = new Checker(await getConfig());
     try {
       await checker.checkApis();
       fail();
@@ -91,7 +91,7 @@ describe("checker", () => {
             Promise.resolve({ data: defaultApis, status: status }),
           ),
       }));
-      const checker = new Checker(new Config());
+      const checker = new Checker(await getConfig());
       try {
         await checker.checkApis();
         fail("expected error");
@@ -114,7 +114,7 @@ describe("checker", () => {
             Promise.resolve({ data: defaultVersions, status: status }),
           ),
       }));
-      const checker = new Checker(new Config());
+      const checker = new Checker(await getConfig());
       try {
         await checker.checkApis();
         fail("expected error");
@@ -136,7 +136,7 @@ describe("checker", () => {
         )
         .mockImplementationOnce(() => Promise.reject(new Error("bad wolf"))),
     }));
-    const checker = new Checker(new Config());
+    const checker = new Checker(await getConfig());
     try {
       await checker.checkApis();
       fail("expected error");
@@ -159,7 +159,7 @@ describe("checker", () => {
           Promise.resolve({ data: 42, status: 200 }),
         ),
     }));
-    const checker = new Checker(new Config());
+    const checker = new Checker(await getConfig());
     try {
       await checker.checkApis();
       fail("expected error");

--- a/src/woollypully/__tests__/config.test.ts
+++ b/src/woollypully/__tests__/config.test.ts
@@ -1,33 +1,72 @@
-import { Config } from "../config";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { getConfig } from "../config";
 
 describe("config", () => {
   beforeEach(() => {
     delete process.env.PROPOSED_SERVICE_URL;
     delete process.env.CURRENT_SERVICE_URL;
+    delete process.env.CERBERUS_CONFIG_PATH;
     delete process.env.PORT;
   });
 
-  test("missing PROPOSED_SERVICE_URL", () => {
-    expect(() => {
-      new Config();
-    }).toThrowError("missing PROPOSED_SERVICE_URL");
+  test("missing PROPOSED_SERVICE_URL, failed to load Cerberus config", async () => {
+    try {
+      await getConfig();
+      fail();
+    } catch (err: any) {
+      expect(err.message).toMatch("failed to load Cerberus config");
+    }
   });
 
-  test("minimum configuration", () => {
+  test("missing PROPOSED_SERVICE_URL, Cerberus config missing upstream", async () => {
+    const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), "cerberus-"));
+    try {
+      const confPath = path.join(tempdir, "cerberus.yaml");
+      await fs.writeFile(confPath, "{}");
+      process.env.CERBERUS_CONFIG_PATH = confPath;
+      await getConfig();
+      fail();
+    } catch (err: any) {
+      expect(err.message).toMatch("failed to determine proposed service URL");
+    } finally {
+      await fs.rm(tempdir, { force: true, recursive: true });
+    }
+  });
+
+  test("minimum configuration", async () => {
     process.env["PROPOSED_SERVICE_URL"] = "http://localhost:8889";
-    const config = new Config();
+    const config = await getConfig();
     expect(config.proposedBaseURL).toEqual("http://localhost:8889");
     expect(config.currentBaseURL).toBeUndefined();
     expect(config.listenPort).toEqual(30576);
   });
 
-  test("everything configured", () => {
+  test("everything configured", async () => {
     process.env["PROPOSED_SERVICE_URL"] = "http://localhost:8889";
     process.env["CURRENT_SERVICE_URL"] = "http://some-thing:8889";
     process.env["PORT"] = "9101";
-    const config = new Config();
+    const config = await getConfig();
     expect(config.proposedBaseURL).toEqual("http://localhost:8889");
     expect(config.currentBaseURL).toEqual("http://some-thing:8889");
     expect(config.listenPort).toEqual(9101);
+  });
+
+  test("configured from Cerberus config upstream", async () => {
+    const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), "cerberus-"));
+    try {
+      const confPath = path.join(tempdir, "cerberus.yaml");
+      await fs.writeFile(
+        confPath,
+        `{"upstream": {"address": "http://localhost:9999"}}`,
+      );
+      process.env.CERBERUS_CONFIG_PATH = confPath;
+      const config = await getConfig();
+      expect(config.proposedBaseURL).toEqual("http://localhost:9999");
+    } finally {
+      await fs.rm(tempdir, { force: true, recursive: true });
+    }
   });
 });

--- a/src/woollypully/__tests__/static_readiness_ok/Tiltfile
+++ b/src/woollypully/__tests__/static_readiness_ok/Tiltfile
@@ -1,3 +1,3 @@
-docker_build('woollypully', '../../../..', dockerfile='../../../../Dockerfile.woollypully')
+docker_build('gcr.io/snyk-main/woollypully', '../../../..', dockerfile='../../../../Dockerfile.woollypully')
 docker_build('fake-service', 'fake-service', dockerfile='fake-service/Dockerfile')
 k8s_yaml(['fake-service/k8s/deployment.yaml'])

--- a/src/woollypully/__tests__/static_readiness_ok/Tiltfile
+++ b/src/woollypully/__tests__/static_readiness_ok/Tiltfile
@@ -1,3 +1,9 @@
-docker_build('gcr.io/snyk-main/woollypully', '../../../..', dockerfile='../../../../Dockerfile.woollypully')
+allow_k8s_contexts(['docker-desktop', 'kind-kind'])
+
+docker_build('gcr.io/snyk-main/woollypully-sidecar', '../../../..', dockerfile='../../../../Dockerfile.woollypully')
+local('kind load docker-image gcr.io/snyk-main/cerberus-sidecar:1.6.0')
 docker_build('fake-service', 'fake-service', dockerfile='fake-service/Dockerfile')
-k8s_yaml(['fake-service/k8s/deployment.yaml'])
+k8s_yaml([
+  'fake-service/k8s/cerberus-configmap.yaml',
+  'fake-service/k8s/deployment.yaml',
+])

--- a/src/woollypully/__tests__/static_readiness_ok/fake-service/k8s/cerberus-configmap.yaml
+++ b/src/woollypully/__tests__/static_readiness_ok/fake-service/k8s/cerberus-configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cerberus-config
+data:
+  authorization-service-secret: AAAAAAAAAAAAAAAAAAAAAA==
+  cerberus.yaml: |-
+    filters:
+      request:
+        authn:
+          strategies:
+            InternalJwt:
+              issuers:
+                "http://localhost":
+                  keys: {}
+        audit:
+          client:
+            address: "mock:8082"
+        authz:
+          client:
+            baseUrl: "http://mock:8081"
+            tokenPath: "/config/authorization-service-secret"
+            tokenType: "Bearer"
+            version: "2021-10-27"
+        test_filter:
+          str: "test req string"
+          boolean: true
+          int: 1234
+      response:
+        test_filter:
+          str: "test res string"
+          boolean: false
+          int: 456
+
+    envoy:
+      grpc:
+        port: 1234
+        termination_grace_period: "5s"
+        access_log_service:
+          ignored_paths:
+            - "/healthcheck"
+
+    upstream:
+      address: http://localhost:8080

--- a/src/woollypully/__tests__/static_readiness_ok/fake-service/k8s/deployment.yaml
+++ b/src/woollypully/__tests__/static_readiness_ok/fake-service/k8s/deployment.yaml
@@ -21,9 +21,9 @@ spec:
           ports:
             - containerPort: 8080
 
-        # TODO: inject woollypully sidecar with admission webhook
+        # Simulate the admission webhook injecting the woollypully sidecar.
         - name: woollypully
-          image: woollypully
+          image: gcr.io/snyk-main/woollypully
           imagePullPolicy: Always
           ports:
             - containerPort: 30576
@@ -33,9 +33,9 @@ spec:
             - name: PORT
               value: "30576"
 
-      # TODO: inject woollypully readiness probe with admission webhook
-      # Pod is not considered Ready until the probe gets a 200 OK.
-      # woollypully doesn't respond 200 OK until governance check on the service container passes.
+          # Simulate the admission webhook injecting the woollypully readiness probe.
+          # Pod is not considered Ready until the probe gets a 200 OK.
+          # woollypully doesn't respond 200 OK until governance check on the service container passes.
           readinessProbe:
             httpGet:
               port: 30576

--- a/src/woollypully/__tests__/static_readiness_ok/fake-service/k8s/deployment.yaml
+++ b/src/woollypully/__tests__/static_readiness_ok/fake-service/k8s/deployment.yaml
@@ -14,28 +14,68 @@ spec:
       labels:
         app: fake-service
     spec:
+      volumes:
+        - name: cerberus-config
+          configMap:
+            name: cerberus-config
       containers:
+        # A fake service onto which woollypully will perform API validation.
         - name: fake-service
           image: fake-service
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
 
+        # Add Cerberus with just enough config to not crash and for woollypully
+        # to find the upstream.
+        - name: cerberus-sidecar
+          image: gcr.io/snyk-main/cerberus-sidecar:1.6.0
+          imagePullPolicy: Never
+          args:
+            - -config
+            - /config/cerberus.yaml
+          command:
+            - ./cerberus-sidecar
+          env:
+            - name: CER_ENV
+              value: test
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 2112
+          ports:
+            - containerPort: 50051
+              name: cerberus-grpc
+              protocol: TCP
+            - containerPort: 2112
+              name: cerberus-http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 2112
+          volumeMounts:
+            - mountPath: /config/
+              name: cerberus-config
+          
         # Simulate the admission webhook injecting the woollypully sidecar.
-        - name: woollypully
-          image: gcr.io/snyk-main/woollypully
+        - name: woollypully-sidecar
+          image: gcr.io/snyk-main/woollypully-sidecar
           imagePullPolicy: Always
           ports:
             - containerPort: 30576
           env:
-            - name: PROPOSED_SERVICE_URL
-              value: "http://localhost:8080"
             - name: PORT
               value: "30576"
+          volumeMounts:
+            - mountPath: /cerberus/config
+              name: cerberus-config
 
           # Simulate the admission webhook injecting the woollypully readiness probe.
           # Pod is not considered Ready until the probe gets a 200 OK.
-          # woollypully doesn't respond 200 OK until governance check on the service container passes.
+          #
+          # woollypully doesn't respond 200 OK until governance check on the
+          # service container passes.
           readinessProbe:
             httpGet:
               port: 30576

--- a/src/woollypully/config.ts
+++ b/src/woollypully/config.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs/promises";
+import * as yaml from "yaml";
+
 /**
  * Config defines configuration for the woollypully application.
  *
@@ -20,22 +23,52 @@ export class Config {
   readonly currentBaseURL?: string;
   readonly listenPort: number;
 
-  constructor() {
-    const proposedBaseURL = process.env["PROPOSED_SERVICE_URL"];
-    if (!proposedBaseURL) {
-      throw new Error("missing PROPOSED_SERVICE_URL");
-    }
+  constructor(
+    proposedBaseURL: string,
+    currentBaseURL: string | undefined,
+    listenPort: number,
+  ) {
     this.proposedBaseURL = proposedBaseURL;
-
-    const currentBaseURL = process.env["CURRENT_SERVICE_URL"];
-    if (!currentBaseURL) {
-      console.log(
-        "warning: CURRENT_SERVICE_URL not specified; lifecycle rules cannot be verified",
-      );
-      this.currentBaseURL = undefined;
-    } else {
-      this.currentBaseURL = currentBaseURL;
-    }
-    this.listenPort = parseInt(process.env["PORT"] ?? "30576");
+    this.currentBaseURL = currentBaseURL;
+    this.listenPort = listenPort;
   }
 }
+
+export const getConfig = async (): Promise<Config> => {
+  let proposedBaseURL: string | undefined = process.env["PROPOSED_SERVICE_URL"];
+  if (!proposedBaseURL) {
+    proposedBaseURL = await loadCerberusUpstreamURL(
+      process.env["CERBERUS_CONFIG_PATH"],
+    );
+  }
+  if (!proposedBaseURL) {
+    throw new Error("failed to determine proposed service URL");
+  }
+
+  const currentBaseURL: string | undefined = process.env["CURRENT_SERVICE_URL"];
+  if (!currentBaseURL) {
+    console.log(
+      "warning: CURRENT_SERVICE_URL not specified; lifecycle rules cannot be verified",
+    );
+  }
+
+  const listenPort = parseInt(process.env["PORT"] ?? "30576");
+
+  return new Config(proposedBaseURL!, currentBaseURL, listenPort);
+};
+
+/**
+ * loadCerberusUpstreamURL loads the upstream URL from the given Cerberus config
+ * file path.
+ */
+export const loadCerberusUpstreamURL = async (
+  cerberusConfigPath = "/cerberus/config/cerberus.yaml",
+): Promise<string | undefined> => {
+  try {
+    const cerberusYAML = await fs.readFile(cerberusConfigPath);
+    const cerberusConfig = yaml.parse(cerberusYAML.toString());
+    return cerberusConfig?.upstream?.address ?? undefined;
+  } catch (err) {
+    throw new Error(`failed to load Cerberus config ${cerberusConfigPath}`);
+  }
+};

--- a/src/woollypully/index.ts
+++ b/src/woollypully/index.ts
@@ -2,16 +2,19 @@
 
 import * as http from "http";
 
-import { Config } from "./config";
+import { getConfig } from "./config";
 import { Checker } from "./checker";
 
-const config = new Config();
-const checker = new Checker(config);
+const main = async (): Promise<number> => {
+  const config = await getConfig();
+  const checker = new Checker(config);
+  await checker.checkApis();
+  return config.listenPort;
+};
 
-// Check APIs on the proposed service container.
-checker
-  .checkApis()
-  .then(() => {
+// Configure & check APIs on the proposed service container.
+main()
+  .then((listenPort: number) => {
     // Then run a simple http server
     // that can answer readiness probes.
     http
@@ -21,7 +24,7 @@ checker
         res.end();
       })
       .on("error", (err) => console.log(err))
-      .listen(config.listenPort, () => {
+      .listen(listenPort, () => {
         console.log("listening for readiness probe");
       });
     console.log("all checks passed");

--- a/yarn.lock
+++ b/yarn.lock
@@ -11115,6 +11115,11 @@ yaml@^1.10.0, yaml@^1.7.2, yaml@^1.9.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
+  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
+
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"


### PR DESCRIPTION
This adds support for discovering the proposed service address from its
cerberus config. The webhook (sweater-comb-admissions) uses the presence
of a cerberus sidecar to decide whether to add API governance to the
Pod, and will add a woollypully sidecar with a cerberus configmap volume
mount.