### PR TITLE
chore: Add 422 status to common components

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -406,6 +406,19 @@ responses:
     content:
       application/vnd.api+json:
         schema: { $ref: '#/schemas/ErrorDocument' }
+
+  '422':
+    description: 'Unprocessable Entity: Unable to process the contained instructions of the requested operation.'
+    headers:
+      snyk-version-requested: { $ref: '#/headers/VersionRequestedResponseHeader' }
+      snyk-version-served: { $ref: '#/headers/VersionServedResponseHeader' }
+      snyk-request-id: { $ref: '#/headers/RequestIdResponseHeader' }
+      snyk-version-lifecycle-stage: { $ref: '#/headers/VersionStageResponseHeader' }
+      deprecation: { $ref: '#/headers/DeprecationHeader' }
+      sunset: { $ref: '#/headers/SunsetHeader' }
+    content:
+      application/vnd.api+json:
+        schema: { $ref: '#/schemas/ErrorDocument' }
   
   '500':
     description: 'Internal Server Error: An error was encountered while attempting to process the request.'

--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -233,6 +233,10 @@ A not found status code & error response must be returned if the requested resou
 
 A conflict status code & error response must be returned if a requested _write_ action cannot be performed because it collides with some constraint (e.g. a unique constraint violation). This status code is also useful when processing idempotent requests which currently are not supported as a part of the Snyk API.
 
+### 422 - Unprocessable Entity
+
+The server understands the content type of the request entity (hence a `415 Unsupported Media Type` status code is inappropriate), and the syntax of the request entity is correct (thus a `400 Bad Request` status code is inappropriate) but was unable to process the contained instructions. For example, if a user attempts to create a new user with a duplicate username, the server should return a `422 Unprocessable Entity` error.
+
 ### 429 - Too Many Requests
 
 A too many requests status code & error response must be returned if the requester has exceeded their request quota for some given time period.


### PR DESCRIPTION
This is proposal PR to include `422 Unprocessable Entity` in the common components.
Having this status code in the schema will make API responses more flexible and granular.
As long as will help us to avoid overuse of `400 Bad Request`.

As this is draft PR it does not include actual changes in the code and tests, like extending `valid4xxCodes`, for example. 