### PR TITLE
Added further properties to error link

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -45,6 +45,12 @@ schemas:
     description: A link that leads to further details about this particular occurrance of the problem.
     properties:
       about: { $ref: "#/schemas/LinkProperty" }
+      self: { $ref: "#/schemas/LinkProperty" }
+      related: { $ref: "#/schemas/LinkProperty" }
+      first: { $ref: "#/schemas/LinkProperty" }
+      last: { $ref: "#/schemas/LinkProperty" }
+      prev: { $ref: "#/schemas/LinkProperty" }
+      next: { $ref: "#/schemas/LinkProperty" }
     additionalProperties: false
     example:
       about: "https://example.com/about_this_error"


### PR DESCRIPTION
This change extends the definition of `ErrorLink` to include other available error properties, such as self, related, and pagination properties. 

This update ensures the definition of error links in `rest-node-libs` now matches the OpenAPI definition. This slightly extends [this pull request](https://github.com/snyk/sweater-comb/pull/312/files) to use further properties. 