### PR TITLE
fix: allow breaking removals in a spec being removed

### DIFF
--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/operation-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/operation-rules.test.ts.snap
@@ -7610,6 +7610,51 @@ Array [
 ]
 `;
 
+exports[`operationId when set passes if removed with a spec being removed 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "removed",
+      "location": Object {
+        "conceptualLocation": Object {
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example",
+          "get",
+        ],
+        "jsonPath": "/paths/~1example/get",
+        "kind": "operation",
+      },
+      "removed": Object {
+        "before": Object {
+          "method": "get",
+          "operationId": "getExample",
+          "pathPattern": "/example",
+          "summary": "this is an example",
+          "tags": Array [
+            "example",
+          ],
+        },
+      },
+    },
+    "condition": "not be allowed",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "expected operation to be present",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent operation removal",
+    "passed": false,
+    "received": undefined,
+    "where": "removed operation: GET /example",
+  },
+]
+`;
+
 exports[`operationId when set passes when camel case and has a hump 1`] = `
 Array [
   Object {

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap
@@ -730,6 +730,8 @@ Array [
 ]
 `;
 
+exports[`body properties breaking changes passes if spec is removed 1`] = `Array []`;
+
 exports[`body properties key allows non-snake case if already in spec 1`] = `
 Array [
   Object {

--- a/src/rulesets/rest/2022-05-25/__tests__/operation-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/operation-rules.test.ts
@@ -205,6 +205,38 @@ describe("operationId", () => {
       expect(results).toMatchSnapshot();
     });
 
+    test("passes if removed with a spec being removed", () => {
+      const ruleRunner = new RuleRunner([operationRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(
+          {
+            ...baseJson,
+            paths: {
+              "/example": {
+                get: {
+                  summary: "this is an example",
+                  tags: ["example"],
+                  parameters: [
+                    {
+                      name: "version",
+                      in: "query",
+                    },
+                  ],
+                  operationId: "getExample",
+                  responses: {},
+                },
+              },
+            },
+          } as OpenAPIV3.Document,
+          baseJson,
+        ),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toMatchSnapshot();
+    });
+
     test("fails if changed", () => {
       const ruleRunner = new RuleRunner([operationRules]);
       const ruleInputs = {

--- a/src/rulesets/rest/2022-05-25/__tests__/property-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/property-rules.test.ts
@@ -925,6 +925,37 @@ describe("body properties", () => {
       expect(results).toMatchSnapshot();
     });
 
+    test("passes if spec is removed", () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {},
+                    },
+                  },
+                },
+              },
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, baseOpenAPI),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
     test("fails if a required property is added", () => {
       const ruleRunner = new RuleRunner([propertyRules]);
       const beforeSpec: OpenAPIV3.Document = {

--- a/src/rulesets/rest/2022-05-25/property-rules.ts
+++ b/src/rulesets/rest/2022-05-25/property-rules.ts
@@ -10,6 +10,7 @@ import {
   isBreakingChangeAllowed,
   isCompiledOperationSunsetAllowed,
   isResourceMetaProperty,
+  specIsRemoved,
 } from "./utils";
 
 const snakeCase = /^[a-z]+(?:_[a-z\d]+)*$/;
@@ -51,6 +52,7 @@ const requestPropertyRemovalRule = {
   docsLink: links.versioning.breakingChanges,
   matches: (specification, ruleContext) =>
     ruleContext.operation.change !== "added" &&
+    !specIsRemoved(specification) &&
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (requestAssertions) => {
     requestAssertions.property.removed("not be removed", (property) => {
@@ -77,6 +79,7 @@ const responsePropertyRemovalRule = {
   docsLink: links.versioning.breakingChanges,
   matches: (specification, ruleContext) =>
     ruleContext.operation.change !== "added" &&
+    !specIsRemoved(specification) &&
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
   rule: (responseAssertions) => {
     responseAssertions.property.removed("not be removed", (property) => {

--- a/src/rulesets/rest/2022-05-25/utils.ts
+++ b/src/rulesets/rest/2022-05-25/utils.ts
@@ -61,3 +61,7 @@ export const isResourceMetaProperty = (property: Field): boolean => {
     ) !== null;
   return isResourceMetaProperty;
 };
+
+export const specIsRemoved = (spec): boolean => {
+  return spec.change === "removed";
+};


### PR DESCRIPTION
When a spec is sunset it can be removed; the lifecycle checks are done
on the compiled version to ensure that the spec can be removed, but
sweater-comb complains about the removal of properties and operations as
part of the spec being deleted.

Since there's a check to ensure it's safe for the spec to be removed,
this commit allows the removal of operations and properties as part of
the spec deletion.