### PR TITLE
feat: sweater-comb lint command

### DIFF
--- a/end-end-tests/api-standards/.vervet.yaml
+++ b/end-end-tests/api-standards/.vervet.yaml
@@ -1,0 +1,8 @@
+linters:
+  some-linter:
+    original: main
+apis:
+  some-api:
+    resources:
+      - path: resources
+        linter: some-linter

--- a/src/__tests__/lint.test.ts
+++ b/src/__tests__/lint.test.ts
@@ -1,0 +1,83 @@
+import * as os from "os";
+import * as uuid from "uuid";
+import { lintAction } from "../lint";
+
+// Tests which spawn subprocesses seem to take longer to execute in CircleCI
+const testTimeout = 30000;
+
+describe("lint command", () => {
+  let pushd: string;
+  beforeEach(async () => {
+    pushd = process.cwd();
+    process.chdir(__dirname + "/../..");
+  });
+  afterEach(async () => {
+    process.chdir(pushd);
+  });
+
+  it(
+    "can lint with path given",
+    async () => {
+      try {
+        await lintAction("end-end-tests/api-standards/resources");
+      } catch (err) {
+        fail(err);
+      }
+    },
+    testTimeout,
+  );
+
+  it(
+    "can lint with path and branch given",
+    async () => {
+      try {
+        await lintAction("end-end-tests/api-standards/resources", "main");
+      } catch (err) {
+        fail(err);
+      }
+    },
+    testTimeout,
+  );
+
+  it(
+    "can lint with .vervet.yaml",
+    async () => {
+      // cd to location where a .vervet.yaml will be found
+      process.chdir("end-end-tests/api-standards");
+      try {
+        await lintAction();
+      } catch (err) {
+        fail(err);
+      }
+    },
+    testTimeout,
+  );
+
+  it("errors with invalid branch given", async () => {
+    try {
+      await lintAction(
+        "end-end-tests/api-standards/resources",
+        // a branch that should not exist
+        "no-such-branch-" + uuid.v4(),
+      );
+      fail("should have thrown an error");
+    } catch (err: any) {
+      expect(err.message).toContain(
+        "bulk-compare end-end-tests/api-standards/resources failed with exit code 1",
+      );
+    }
+  });
+
+  it("errors when .vervet.yaml cannot be found", async () => {
+    // cd to where no .vervet.yaml will be found
+    process.chdir(os.tmpdir());
+    try {
+      await lintAction();
+      fail("should have thrown an error");
+    } catch (err: any) {
+      expect(err.message).toContain(
+        "cannot find .vervet.yaml -- is this a Vervet-managed API project?",
+      );
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   createVersionCommand,
   createUpdateCommand,
 } from "./workflows/commands";
+import { createLintCommand } from "./lint";
 
 const rulesets = {
   resource: resourceRules,
@@ -97,6 +98,7 @@ const readContextFrom = (
 
   workflowCommand.addCommand(operationCommand);
   cli.addCommand(workflowCommand);
+  cli.addCommand(createLintCommand());
 
   cli.parse(process.argv);
 })();

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,142 @@
+import findParentDir from "find-parent-dir";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as util from "util";
+import * as child_process from "child_process";
+import { loadYaml } from "@useoptic/openapi-io";
+import { Argument, Command } from "commander";
+
+const findParentDirAsync = util.promisify(findParentDir);
+
+type VervetConfig = {
+  linters: {
+    [linterKey: string]: {
+      "optic-ci"?: {
+        original?: string;
+        script?: string;
+        exceptions?: {
+          [key: string]: string[];
+        };
+      };
+    };
+  };
+  apis: {
+    [apiKey: string]: {
+      resources: Array<{
+        path: string;
+        linter?: string;
+        excludes?: string[];
+      }>;
+    };
+  };
+};
+
+const defaultBranchName = "main";
+
+export const lintAction = async (resourceDir?: string, branchName?: string) => {
+  if (resourceDir) {
+    await bulkCompare(resourceDir, branchName ?? defaultBranchName);
+    return;
+  }
+
+  console.log(
+    "no arguments given, defaulting to Vervet API project configuration",
+  );
+  const vervetConfDir = await findParentDirAsync(
+    path.resolve(process.cwd()),
+    ".vervet.yaml",
+  );
+  if (!vervetConfDir) {
+    throw new Error(
+      "cannot find .vervet.yaml -- is this a Vervet-managed API project?",
+    );
+  }
+  const vervetConfFile = path.join(vervetConfDir, ".vervet.yaml");
+  const vervetConfContents = await fs.readFile(vervetConfFile);
+  const vervetConf = loadYaml(vervetConfContents.toString()) as VervetConfig;
+
+  for (const [apiKey, apiValue] of Object.entries(vervetConf.apis)) {
+    console.log(`Linting API ${apiKey}`);
+    for (const resource of apiValue.resources) {
+      if (!resource.linter) {
+        console.log(`skipping API ${apiKey}: no linter`);
+        continue;
+      }
+      if (resource.excludes) {
+        throw new Error("vervet resource exclude paths are not supported");
+      }
+      const linter = vervetConf.linters[resource.linter];
+      if (!linter || !linter["optic-ci"]) {
+        console.log(`skipping API ${apiKey}: not linted with optic-ci`);
+        continue;
+      }
+      const base = linter["optic-ci"]?.original ?? defaultBranchName;
+      await bulkCompare(resource.path, base);
+    }
+  }
+};
+
+export const createLintCommand = () => {
+  const command = new Command("lint")
+    .addArgument(new Argument("path", "API resource path").argOptional())
+    .addArgument(
+      new Argument("base", "base git branch for comparison")
+        .argOptional()
+        .default(defaultBranchName),
+    )
+    .action(lintAction);
+  command.description("lint APIs in current project");
+  return command;
+};
+
+const bulkCompare = async (resourceDir: string, base: string) => {
+  const opticScript = await resolveOpticScript();
+  await new Promise<void>((resolve, reject) => {
+    const child = child_process.spawn(
+      process.argv0,
+      [
+        opticScript,
+        "bulk-compare",
+        "--glob",
+        `${resourceDir}/**/[2-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]/spec.yaml`,
+        "--base",
+        base,
+      ],
+      {
+        env: {
+          ...process.env,
+        },
+        stdio: "inherit",
+      },
+    );
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `bulk-compare ${resourceDir} failed with exit code ${code}`,
+          ),
+        );
+      }
+    });
+  });
+};
+
+const resolveOpticScript = async (): Promise<string> => {
+  for (const script of [
+    path.join(__dirname, "../build/index.js"),
+    path.join(__dirname, "index.js"),
+  ]) {
+    try {
+      await fs.stat(script);
+      return script;
+    } catch (err) {
+      continue;
+    }
+  }
+  throw new Error("failed to locate optic-ci script");
+};

--- a/src/woollypully/__tests__/checker.test.ts
+++ b/src/woollypully/__tests__/checker.test.ts
@@ -7,6 +7,9 @@ import { Checker } from "../checker";
 
 import { getConfig } from "../config";
 
+// Tests which spawn subprocesses seem to take longer to execute in CircleCI
+const testTimeout = 30000;
+
 jest.mock("axios");
 jest.mock("@useoptic/openapi-io");
 
@@ -43,42 +46,50 @@ describe("checker", () => {
     jest.resetAllMocks();
   });
 
-  test("can check APIs", async () => {
-    (axios.default.create as jest.Mock).mockImplementation(() => ({
-      get: jest
-        .fn()
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultApis, status: 200 }),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultVersions, status: 200 }),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultSpecJson, status: 200 }),
-        ),
-    }));
-    const checker = new Checker(await getConfig());
-    try {
-      await checker.checkApis();
-    } catch (err: any) {
-      fail(err.message);
-    }
-  }, 30000);
+  test(
+    "can check APIs",
+    async () => {
+      (axios.default.create as jest.Mock).mockImplementation(() => ({
+        get: jest
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultApis, status: 200 }),
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultVersions, status: 200 }),
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultSpecJson, status: 200 }),
+          ),
+      }));
+      const checker = new Checker(await getConfig());
+      try {
+        await checker.checkApis();
+      } catch (err: any) {
+        fail(err.message);
+      }
+    },
+    testTimeout,
+  );
 
-  test("fails if service is unavailable", async () => {
-    (axios.default.create as jest.Mock).mockImplementation(() => ({
-      get: jest
-        .fn()
-        .mockImplementation(() => Promise.reject(new Error("bad wolf"))),
-    }));
-    const checker = new Checker(await getConfig());
-    try {
-      await checker.checkApis();
-      fail();
-    } catch (err: any) {
-      expect(err.message).toMatch("bad wolf");
-    }
-  });
+  test(
+    "fails if service is unavailable",
+    async () => {
+      (axios.default.create as jest.Mock).mockImplementation(() => ({
+        get: jest
+          .fn()
+          .mockImplementation(() => Promise.reject(new Error("bad wolf"))),
+      }));
+      const checker = new Checker(await getConfig());
+      try {
+        await checker.checkApis();
+        fail();
+      } catch (err: any) {
+        expect(err.message).toMatch("bad wolf");
+      }
+    },
+    testTimeout,
+  );
 
   test.each([400, 404, 500])(
     "fails if apis request responds with %s",
@@ -98,6 +109,7 @@ describe("checker", () => {
         expect(err.message).toMatch("failed to obtain APIs");
       }
     },
+    testTimeout,
   );
 
   test.each([400, 404, 500])(
@@ -121,51 +133,60 @@ describe("checker", () => {
         expect(err.message).toMatch("failed to obtain OpenAPI versions");
       }
     },
+    testTimeout,
   );
 
-  test("fails if spec request fails", async () => {
-    (axios.default.create as jest.Mock).mockImplementation(() => ({
-      get: jest
-        .fn()
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultApis, status: 200 }),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultVersions, status: 200 }),
-        )
-        .mockImplementationOnce(() => Promise.reject(new Error("bad wolf"))),
-    }));
-    const checker = new Checker(await getConfig());
-    try {
-      await checker.checkApis();
-      fail("expected error");
-    } catch (err: any) {
-      expect(err.message).toMatch("bad wolf");
-    }
-  });
+  test(
+    "fails if spec request fails",
+    async () => {
+      (axios.default.create as jest.Mock).mockImplementation(() => ({
+        get: jest
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultApis, status: 200 }),
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultVersions, status: 200 }),
+          )
+          .mockImplementationOnce(() => Promise.reject(new Error("bad wolf"))),
+      }));
+      const checker = new Checker(await getConfig());
+      try {
+        await checker.checkApis();
+        fail("expected error");
+      } catch (err: any) {
+        expect(err.message).toMatch("bad wolf");
+      }
+    },
+    testTimeout,
+  );
 
-  test("fails if spec is invalid", async () => {
-    (axios.default.create as jest.Mock).mockImplementation(() => ({
-      get: jest
-        .fn()
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultApis, status: 200 }),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: defaultVersions, status: 200 }),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve({ data: 42, status: 200 }),
-        ),
-    }));
-    const checker = new Checker(await getConfig());
-    try {
-      await checker.checkApis();
-      fail("expected error");
-    } catch (err: any) {
-      expect(err.message).toMatch(
-        "check 2022-05-23~beta failed with exit code 1",
-      );
-    }
-  });
+  test(
+    "fails if spec is invalid",
+    async () => {
+      (axios.default.create as jest.Mock).mockImplementation(() => ({
+        get: jest
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultApis, status: 200 }),
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: defaultVersions, status: 200 }),
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve({ data: 42, status: 200 }),
+          ),
+      }));
+      const checker = new Checker(await getConfig());
+      try {
+        await checker.checkApis();
+        fail("expected error");
+      } catch (err: any) {
+        expect(err.message).toMatch(
+          "check 2022-05-23~beta failed with exit code 1",
+        );
+      }
+    },
+    testTimeout,
+  );
 });


### PR DESCRIPTION
Lint command which frontends optic-ci's bulk-compare, using the
project's .vervet.yaml to derive the base ref and glob patterns.