### PR TITLE
feat: add meta_count query parameter component

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -340,6 +340,17 @@ parameters:
     example: "2021-06-04"
     schema: { $ref: "#/schemas/QueryVersion" }
 
+  MetaCount:
+    name: meta_count
+    in: query
+    description: State the number of objects in a collection
+    example: only
+    schema:
+      type: string
+      enum:
+        - only
+        - with
+
 responses:
 
   '204':


### PR DESCRIPTION
meta_count is defined in our standards (docts/standards/rest.md) to
specify how we return the meta.count object in the response. This is
useful for clients that only need a count of the objects and not the
objects themselves.