### PR TITLE
fix: pin sweater-comb commander to compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chai": "^4.3.4",
     "chalk": "^4.0.0",
     "change-case": "^4.1.2",
-    "commander": "^9.4.0",
+    "commander": "9.0.0",
     "find-parent-dir": "^0.3.1",
     "fs-extra": "^10.0.0",
     "lodash.isequal": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4358,7 +4358,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^9.0.0:
+commander@9.0.0, commander@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
   integrity sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==
@@ -4372,11 +4372,6 @@ commander@^9.3.0:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
   integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
-
-commander@^9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
-  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
 common-tags@^1.8.0:
   version "1.8.2"


### PR DESCRIPTION
@jcsackett reported an issue where yarn installs were leading to internal errors. I was able to reproduce this locally and found that the issue was in `commander` package. Optic uses a different minor version than Snyk and a recent change on our end led to conflicting node_modules. Yarn and NPM handle those conflicts differently and that's why we're seeing different behavior between the two. 

There are changes coming to custom rule setups that should insource more of these concerns to the SDKs and lead to fewer dependencies in your project. Pinning should keep everything consistent for the time being :)