### PR TITLE
fix: allows dotted notation in query params

### DIFF
--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -237,6 +237,10 @@ A filter parameter may support a single value to match, or a set of multiple val
 
 Changing a parameter's schema from a single value to multiple values is a non-breaking API change. The inverse however (changing from supporting multple values to a single value) is a breaking API change.
 
+#### Filtering through sub properties
+
+Sub properties may also be used for filtering; when filtering on sub properties, filters are expressed as ?property_name.sub_property_name=sub_property_value.
+
 #### Filtering through relationships
 
 A resource's relationships' properties may be used to filter a query as well. When filtering on values in a resource's relationships, the filter is expressed in the form `?relationship_name.property_name=property_value`. For example, if a query were filtering on a resource, `book`, which had a relationship to `author`, the query could filter on the author's name with `?author.name=some_name`.

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/operation-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/operation-rules.test.ts.snap
@@ -3787,6 +3787,45 @@ Array [
   Object {
     "change": Object {
       "added": Object {
+        "in": "query",
+        "name": "prop.sub_prop",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "prop.sub_prop",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "prop.sub_prop",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/2",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#parameter-names-and-path-components",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: prop.sub_prop in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
         "method": "get",
         "operationId": "getExample",
         "pathPattern": "/example/{path_parameter}",
@@ -4206,6 +4245,45 @@ Array [
   Object {
     "change": Object {
       "added": Object {
+        "in": "query",
+        "name": "prop.sub_prop",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "prop.sub_prop",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "prop.sub_prop",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/2",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#parameter-names-and-path-components",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: prop.sub_prop in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
         "method": "get",
         "operationId": "getExample",
         "pathPattern": "/example/{path_parameter}",
@@ -4621,6 +4699,45 @@ Array [
     "passed": true,
     "received": undefined,
     "where": "added query parameter: version in operation: GET /example/{path_parameter}",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "in": "query",
+        "name": "prop.sub_prop",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "prop.sub_prop",
+          },
+          "method": "get",
+          "path": "/example/{path_parameter}",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/example/{}",
+          "get",
+          "parameters",
+          "query",
+          "prop.sub_prop",
+        ],
+        "jsonPath": "/paths/~1example~1{path_parameter}/get/parameters/2",
+        "kind": "query-parameter",
+      },
+    },
+    "condition": "use the correct case",
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#parameter-names-and-path-components",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "operation parameters snake case",
+    "passed": true,
+    "received": undefined,
+    "where": "added query parameter: prop.sub_prop in operation: GET /example/{path_parameter}",
   },
   Object {
     "change": Object {

--- a/src/rulesets/rest/2022-05-25/__tests__/operation-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/operation-rules.test.ts
@@ -3,8 +3,28 @@ import { RuleRunner, TestHelpers } from "@useoptic/rulesets-base";
 import { context } from "./fixtures";
 
 import { operationRulesResource as operationRules } from "../operation-rules";
+import { validDottedName } from "../operation-rules";
 
 const baseJson = TestHelpers.createEmptySpec();
+
+describe("valid dot notation names", () => {
+  test("leading dots are not valid", () => {
+    const name = ".bad.wolf";
+    expect(validDottedName(name)).toBe(false);
+  });
+  test("trailing dots are not valid", () => {
+    const name = "bad.wolf.";
+    expect(validDottedName(name)).toBe(false);
+  });
+  test("consecutive dots are not valid", () => {
+    const name = "bad..wolf";
+    expect(validDottedName(name)).toBe(false);
+  });
+  test("standard dot notation is valid", () => {
+    const name = "bad.wolf";
+    expect(validDottedName(name)).toBe(true);
+  });
+});
 
 test.each(["experimental", "beta", "ga"])(
   "passes when operation is set correctly, stability %s",
@@ -428,6 +448,10 @@ describe("operation parameters", () => {
                     {
                       name: "path_parameter",
                       in: "path",
+                    },
+                    {
+                      name: "prop.sub_prop",
+                      in: "query",
                     },
                   ],
                   operationId: "getExample",

--- a/src/rulesets/rest/2022-05-25/operation-rules.ts
+++ b/src/rulesets/rest/2022-05-25/operation-rules.ts
@@ -14,6 +14,16 @@ import {
   isCompiledOperationSunsetAllowed,
 } from "./utils";
 
+export const validDottedName = (name) => {
+  return (
+    !name.startsWith(".") &&
+    !name.endsWith(".") &&
+    name.split(".").every((n) => {
+      return n !== "" && snakeCase(n) === n;
+    })
+  );
+};
+
 const operationId = new OperationRule({
   name: "operation id",
   docsLink: links.standards.operationIds,
@@ -141,7 +151,7 @@ const parameterCase = new OperationRule({
       "use the correct case",
       (queryParameter) => {
         const name = queryParameter.value.name;
-        if (snakeCase(name) !== name) {
+        if (!validDottedName(name)) {
           throw new RuleError({
             message: `expected parameter name ${name} to be snake case`,
           });


### PR DESCRIPTION
Our standards use `relationship_name.property_name=value` and
`property_name.sub_property=value` for filtering on properties and
relationships. The current snake case rules catch these as rule violations,
when they're valid.

This updates the query param rules to check for snake case on all segments of
a dotted notation path, but doesn't flag the `.` as invalid naming.