### PR TITLE
fix: bulk compare paths relative to git repo, async catch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const readContextFrom = (
   return { date, resource, stability };
 };
 
-(async () => {
+const main = async (): Promise<void> => {
   const cli = await initializeCli({
     token: process.env.OPTIC_TOKEN || "",
     gitProvider: {
@@ -100,5 +100,14 @@ const readContextFrom = (
   cli.addCommand(workflowCommand);
   cli.addCommand(createLintCommand());
 
-  cli.parse(process.argv);
-})();
+  await cli.exitOverride().parseAsync(process.argv);
+};
+
+process.exitCode = 1;
+main()
+  .then(() => {
+    process.exitCode = 0;
+  })
+  .catch((err) => {
+    console.log("exit on error:", err);
+  });


### PR DESCRIPTION
When using bulk-compare with glob, paths must be relative to the git
repository. This may not be the same as the .vervet.yaml directory in
cases where the API project directory is a subdirectory in the cloned
git repo.

Improve exception handling to allow all asynchronous execution to
complete in the top-level catch. It turns out that exiting the process
in the catch may terminate the process before some logged output has a
chance to be written to the terminal output, resulting in a non-zero
exit code with no apparent reason to the user.