### PR TITLE
fix: add JSON API request body validation

### DIFF
--- a/end-end-tests/api-standards/resources/thing/2021-11-10/000-batch-post.yaml
+++ b/end-end-tests/api-standards/resources/thing/2021-11-10/000-batch-post.yaml
@@ -19,7 +19,7 @@ paths:
         - Thing
       parameters:
         - { $ref: "#/components/x-rest-common/parameters/Version" }
-        - { $ref: '#/components/parameters/OrgId' }
+        - { $ref: "#/components/parameters/OrgId" }
       requestBody:
         required: true
         content:
@@ -47,11 +47,8 @@ paths:
                 $ref: "#/components/x-rest-common/headers/VersionStageResponseHeader",
               }
             deprecation:
-              {
-                $ref: "#/components/x-rest-common/headers/DeprecationHeader",
-              }
-            sunset:
-              { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
+              { $ref: "#/components/x-rest-common/headers/DeprecationHeader" }
+            sunset: { $ref: "#/components/x-rest-common/headers/SunsetHeader" }
             location:
               { $ref: "#/components/x-rest-common/headers/LocationHeader" }
         "400": { $ref: "#/components/x-rest-common/responses/400" }
@@ -62,7 +59,7 @@ paths:
         "500": { $ref: "#/components/x-rest-common/responses/500" }
 components:
   x-rest-common:
-    $ref: '../../../../../components/common.yaml'
+    $ref: "../../../../../components/common.yaml"
   parameters:
     OrgId:
       name: org_id
@@ -72,32 +69,18 @@ components:
       schema:
         type: string
         format: uuid
-    ThingId:
-      name: thing_id
-      in: path
-      required: true
-      description: Unique identifier for thing instances
-      schema:
-        type: string
-        format: uuid
   schemas:
     ThingResourceRequest:
       type: object
       description: Request containing a single thing resource object
       properties:
-        jsonapi: { $ref: "#/components/x-rest-common/schemas/JsonApi" }
         data:
           type: array
-          items:  { $ref: "#/components/schemas/ThingResource" }
-        links: { $ref: "#/components/x-rest-common/schemas/SelfLink" }
-    ThingResource:
+          items: { $ref: "#/components/schemas/ThingResourceItem" }
+    ThingResourceItem:
       type: object
       description: thing resource object
       properties:
-        id:
-          type: string
-          format: uuid
-          example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
         type: { $ref: "#/components/x-rest-common/schemas/Types" }
         attributes: { $ref: "#/components/schemas/ThingAttributes" }
         relationships: { $ref: "#/components/schemas/ThingRelationships" }
@@ -108,10 +91,6 @@ components:
       properties:
         example: { $ref: "#/components/x-rest-common/schemas/Relationship" }
       additionalProperties: false
-
-    ThingCollection:
-      type: array
-      items: { $ref: "#/components/schemas/ThingResource" }
 
     ThingAttributes:
       type: object

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -45,5 +45,11 @@ export const links = {
       "https://github.com/snyk/sweater-comb/blob/main/docs/principles/jsonapi.md#pagination-parameters",
     compoundDocuments:
       "https://github.com/snyk/sweater-comb/blob/main/docs/principles/jsonapi.md#compound-documents",
+    postRequests: "https://jsonapi.org/format/#crud-creating",
+    postResponses: "https://jsonapi.org/format/#crud-creating-responses-201",
+    patchRequests: "https://jsonapi.org/format/#crud-updating",
+    patchResponses: "https://jsonapi.org/format/#crud-updating-responses",
+    bulkOperations:
+      "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#bulk-operations",
   },
 };

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`resource object rules invalid patch shapes fails when content is specified for 204 status codes 1`] = `
+exports[`resource object rules invalid PATCH responses fails when content is specified for 204 status codes 1`] = `
 Array [
   Object {
     "change": Object {
@@ -40,6 +40,140 @@ Array [
     "received": undefined,
     "type": "added",
     "where": "PATCH /api/example response 204",
+  },
+]
+`;
+
+exports[`resource object rules valid DELETE responses passes when status code 200 has the correct body 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "delete",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "delete",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/delete/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API type property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "DELETE /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "delete",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "delete",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/delete/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid patch response data schema",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "DELETE /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "",
+        "statusCode": "200",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "delete",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "delete",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1example/delete/responses/200",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "DELETE /api/example response 200",
   },
 ]
 `;
@@ -214,7 +348,7 @@ Array [
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "content for 2xx status codes",
+    "name": "content for non-204 status codes",
     "passed": true,
     "received": undefined,
     "type": "added",
@@ -223,141 +357,7 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid delete shapes passes when status code 200 has the correct body 1`] = `
-Array [
-  Object {
-    "change": Object {
-      "added": Object {
-        "contentType": "application/vnd.api+json",
-        "flatSchema": Object {
-          "type": "object",
-        },
-      },
-      "changeType": "added",
-      "location": Object {
-        "conceptualLocation": Object {
-          "inResponse": Object {
-            "body": Object {
-              "contentType": "application/vnd.api+json",
-            },
-            "statusCode": "200",
-          },
-          "method": "delete",
-          "path": "/api/example",
-        },
-        "conceptualPath": Array [
-          "operations",
-          "/api/example",
-          "delete",
-          "responses",
-          "200",
-          "application/vnd.api+json",
-        ],
-        "jsonPath": "/paths/~1api~1example/delete/responses/200/content/application~1vnd.api+json",
-        "kind": "body",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "include JSON:API type property for 2xx status codes",
-    "passed": true,
-    "received": undefined,
-    "type": "added",
-    "where": "DELETE /api/example response 200 response body: application/vnd.api+json",
-  },
-  Object {
-    "change": Object {
-      "added": Object {
-        "contentType": "application/vnd.api+json",
-        "flatSchema": Object {
-          "type": "object",
-        },
-      },
-      "changeType": "added",
-      "location": Object {
-        "conceptualLocation": Object {
-          "inResponse": Object {
-            "body": Object {
-              "contentType": "application/vnd.api+json",
-            },
-            "statusCode": "200",
-          },
-          "method": "delete",
-          "path": "/api/example",
-        },
-        "conceptualPath": Array [
-          "operations",
-          "/api/example",
-          "delete",
-          "responses",
-          "200",
-          "application/vnd.api+json",
-        ],
-        "jsonPath": "/paths/~1api~1example/delete/responses/200/content/application~1vnd.api+json",
-        "kind": "body",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "valid patch response data schema",
-    "passed": true,
-    "received": undefined,
-    "type": "added",
-    "where": "DELETE /api/example response 200 response body: application/vnd.api+json",
-  },
-  Object {
-    "change": Object {
-      "added": Object {
-        "description": "",
-        "statusCode": "200",
-      },
-      "changeType": "added",
-      "location": Object {
-        "conceptualLocation": Object {
-          "inResponse": Object {
-            "statusCode": "200",
-          },
-          "method": "delete",
-          "path": "/api/example",
-        },
-        "conceptualPath": Array [
-          "operations",
-          "/api/example",
-          "delete",
-          "responses",
-          "200",
-        ],
-        "jsonPath": "/paths/~1api~1example/delete/responses/200",
-        "kind": "response",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "content for 2xx status codes",
-    "passed": true,
-    "received": undefined,
-    "type": "added",
-    "where": "DELETE /api/example response 200",
-  },
-]
-`;
-
-exports[`resource object rules valid patch shapes passes when singleton status code 200 has the correct body 1`] = `
+exports[`resource object rules valid PATCH responses passes when singleton status code 200 has the correct body 1`] = `
 Array [
   Object {
     "change": Object {
@@ -392,7 +392,7 @@ Array [
       },
     },
     "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "docsLink": "https://jsonapi.org/format/#crud-updating-responses",
     "error": undefined,
     "exempted": false,
     "expected": undefined,
@@ -572,7 +572,7 @@ Array [
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "content for 2xx status codes",
+    "name": "content for non-204 status codes",
     "passed": true,
     "received": undefined,
     "type": "added",
@@ -581,7 +581,7 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid patch shapes passes when status code 200 has the correct body 1`] = `
+exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body 1`] = `
 Array [
   Object {
     "change": Object {
@@ -616,7 +616,7 @@ Array [
       },
     },
     "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "docsLink": "https://jsonapi.org/format/#crud-updating-responses",
     "error": undefined,
     "exempted": false,
     "expected": undefined,
@@ -796,7 +796,7 @@ Array [
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "content for 2xx status codes",
+    "name": "content for non-204 status codes",
     "passed": true,
     "received": undefined,
     "type": "added",
@@ -805,7 +805,7 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid patch shapes passes when status code 200 has the correct body, meta only, singleton=false 1`] = `
+exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body, meta only, singleton=false 1`] = `
 Array [
   Object {
     "change": Object {
@@ -840,7 +840,7 @@ Array [
       },
     },
     "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "docsLink": "https://jsonapi.org/format/#crud-updating-responses",
     "error": undefined,
     "exempted": false,
     "expected": undefined,
@@ -1020,7 +1020,7 @@ Array [
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "content for 2xx status codes",
+    "name": "content for non-204 status codes",
     "passed": true,
     "received": undefined,
     "type": "added",
@@ -1029,7 +1029,7 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid patch shapes passes when status code 200 has the correct body, meta only, singleton=true 1`] = `
+exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body, meta only, singleton=true 1`] = `
 Array [
   Object {
     "change": Object {
@@ -1064,7 +1064,7 @@ Array [
       },
     },
     "condition": undefined,
-    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "docsLink": "https://jsonapi.org/format/#crud-updating-responses",
     "error": undefined,
     "exempted": false,
     "expected": undefined,
@@ -1244,7 +1244,7 @@ Array [
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "content for 2xx status codes",
+    "name": "content for non-204 status codes",
     "passed": true,
     "received": undefined,
     "type": "added",
@@ -1253,7 +1253,7 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid post shapes passes when status code 201 has the correct headers and body 1`] = `
+exports[`resource object rules valid POST responses passes when status code 201 has the correct headers and body 1`] = `
 Array [
   Object {
     "change": Object {
@@ -1423,7 +1423,7 @@ Array [
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "content for 2xx status codes",
+    "name": "content for non-204 status codes",
     "passed": true,
     "received": undefined,
     "type": "added",

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -6,6 +6,431 @@ import { resourceObjectRules } from "../resource-object-rules";
 const baseJson = TestHelpers.createEmptySpec();
 
 describe("resource object rules", () => {
+  describe("valid PATCH requests", () => {
+    test("passes when PATCH request body is of the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example/{example_id}": {
+            patch: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            id: {
+                              type: "string",
+                              format: "uuid",
+                            },
+                            type: {
+                              type: "string",
+                            },
+                            attributes: {
+                              type: "object",
+                              properties: {
+                                something: {
+                                  type: "string",
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(true);
+    });
+  });
+
+  describe("valid POST requests", () => {
+    test("passes when POST request body is of the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example": {
+            post: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                            },
+                            attributes: {
+                              type: "object",
+                              properties: {
+                                something: {
+                                  type: "string",
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(true);
+    });
+
+    test("passes when bulk POST request body is of the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example": {
+            post: {
+              responses: {
+                "204": {
+                  description: "it's a bulk POST y'all",
+                },
+              },
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              attributes: {
+                                type: "object",
+                                properties: {
+                                  something: {
+                                    type: "string",
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(true);
+    });
+  });
+
+  describe("invalid PATCH requests", () => {
+    test("fails when PATCH request body is not of the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example/{example_id}": {
+            patch: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        something: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where:
+              "PATCH /api/example/{example_id} request body: application/vnd.api+json",
+            name: "request body for patch",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe("invalid POST requests", () => {
+    test("fails when POST request body is not of the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example": {
+            post: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        something: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where: "POST /api/example request body: application/vnd.api+json",
+            name: "request body for post",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
+    });
+
+    test("fails when bulk POST request body is not the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example": {
+            post: {
+              responses: {
+                "204": {
+                  description: "it's a bulk POST y'all",
+                },
+              }, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        something: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where: "POST /api/example request body: application/vnd.api+json",
+            name: "request body for bulk post",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
+    });
+
+    test("fails when bulk POST request array elements are not of the correct form", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example": {
+            post: {
+              responses: {
+                "204": {
+                  description: "it's a bulk POST y'all",
+                },
+              }, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              something: {
+                                type: "string",
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where: "POST /api/example request body: application/vnd.api+json",
+            name: "request body for bulk post",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
+    });
+
+    test("fails when bulk POST request body is a resource object instead of a collection", () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example": {
+            post: {
+              responses: {
+                "204": {
+                  description: "it's a bulk POST y'all",
+                },
+              },
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                            },
+                            attributes: {
+                              type: "object",
+                              properties: {
+                                something: {
+                                  type: "string",
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where: "POST /api/example request body: application/vnd.api+json",
+            name: "request body for bulk post",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
+    });
+  });
+
   describe("valid GET responses", () => {
     test("passes when status code 200 has the correct JSON body", () => {
       const afterJson = {
@@ -63,7 +488,7 @@ describe("resource object rules", () => {
     });
   });
 
-  describe("valid post shapes", () => {
+  describe("valid POST responses", () => {
     test("passes when status code 201 has the correct headers and body", () => {
       const afterJson = {
         ...baseJson,
@@ -124,7 +549,7 @@ describe("resource object rules", () => {
     });
   });
 
-  describe("valid patch shapes", () => {
+  describe("valid PATCH responses", () => {
     test("passes when status code 200 has the correct body", () => {
       const afterJson = {
         ...baseJson,
@@ -292,7 +717,7 @@ describe("resource object rules", () => {
     });
   });
 
-  describe("valid delete shapes", () => {
+  describe("valid DELETE responses", () => {
     test("passes when status code 200 has the correct body", () => {
       const afterJson = {
         ...baseJson,
@@ -416,7 +841,6 @@ describe("resource object rules", () => {
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
       expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(false);
-      console.log(results.filter((r) => !r.passed));
       expect(results).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -428,7 +852,7 @@ describe("resource object rules", () => {
     });
   });
 
-  describe("invalid patch shapes", () => {
+  describe("invalid PATCH responses", () => {
     test("fails when content is specified for 204 status codes", () => {
       const afterJson = {
         ...baseJson,
@@ -462,79 +886,12 @@ describe("resource object rules", () => {
       expect(results.every((result) => result.passed)).toBe(false);
       expect(results).toMatchSnapshot();
     });
-  });
 
-  test("fails when status code 200 missing resource id", () => {
-    const afterJson = {
-      ...baseJson,
-      paths: {
-        "/api/example": {
-          patch: {
-            responses: {
-              "200": {
-                description: "",
-                content: {
-                  "application/vnd.api+json": {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        data: {
-                          type: "object",
-                          properties: {
-                            type: {
-                              type: "string",
-                            },
-                          },
-                        },
-                        jsonapi: {
-                          type: "string",
-                        },
-                        links: {
-                          properties: {
-                            self: {
-                              type: "string",
-                            },
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    } as OpenAPIV3.Document;
-
-    const ruleRunner = new RuleRunner([resourceObjectRules]);
-    const ruleInputs = {
-      ...TestHelpers.createRuleInputs(baseJson, afterJson),
-      context,
-    };
-    const results = ruleRunner.runRulesWithFacts(ruleInputs);
-    expect(results.length).toBeGreaterThan(0);
-    expect(results.every((result) => result.passed)).toBe(false);
-    expect(results).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: "valid patch response data schema",
-          passed: false,
-          exempted: false,
-          error: "Expected at least one partial match",
-        }),
-      ]),
-    );
-  });
-
-  test.each([true, false])(
-    "fails when status code 200 is empty, singleton=%s",
-    (isSingleton) => {
+    test("fails when status code 200 missing resource id", () => {
       const afterJson = {
         ...baseJson,
         paths: {
           "/api/example": {
-            "x-snyk-resource-singleton": isSingleton,
             patch: {
               responses: {
                 "200": {
@@ -544,8 +901,23 @@ describe("resource object rules", () => {
                       schema: {
                         type: "object",
                         properties: {
+                          data: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                            },
+                          },
                           jsonapi: {
                             type: "string",
+                          },
+                          links: {
+                            properties: {
+                              self: {
+                                type: "string",
+                              },
+                            },
                           },
                         },
                       },
@@ -566,25 +938,76 @@ describe("resource object rules", () => {
       const results = ruleRunner.runRulesWithFacts(ruleInputs);
       expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(false);
-      console.log(results.filter((r) => !r.passed));
       expect(results).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            name: isSingleton
-              ? "valid patch singleton response data schema"
-              : "valid patch response data schema",
+            name: "valid patch response data schema",
             passed: false,
             exempted: false,
             error: "Expected at least one partial match",
           }),
-          expect.objectContaining({
-            name: "self links",
-            passed: false,
-            exempted: false,
-            error: "Expected a partial match",
-          }),
         ]),
       );
-    },
-  );
+    });
+
+    test.each([true, false])(
+      "fails when status code 200 is empty, singleton=%s",
+      (isSingleton) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example": {
+              "x-snyk-resource-singleton": isSingleton,
+              patch: {
+                responses: {
+                  "200": {
+                    description: "",
+                    content: {
+                      "application/vnd.api+json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            jsonapi: {
+                              type: "string",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(false);
+        expect(results).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: isSingleton
+                ? "valid patch singleton response data schema"
+                : "valid patch response data schema",
+              passed: false,
+              exempted: false,
+              error: "Expected at least one partial match",
+            }),
+            expect.objectContaining({
+              name: "self links",
+              passed: false,
+              exempted: false,
+              error: "Expected a partial match",
+            }),
+          ]),
+        );
+      },
+    );
+  });
 });


### PR DESCRIPTION
JSON API rules were missing request body validation for POST and PATCH requests.

Technically a breaking change. However, REST APIs _should_ have been following the standards docs. This is not a standards or policy change -- it's just checking for valid JSON API POST and PATCH requests. Will evaluate the potential impact before landing / releasing.

~~TODO: more comprehensive test coverage~~
~~TODO: smoke test w/an API service~~
~~TODO: update doc links~~