### PR TITLE
fix(workflow): links object in single item responses

### DIFF
--- a/src/workflows/templates/schemas.ts
+++ b/src/workflows/templates/schemas.ts
@@ -25,7 +25,7 @@ export function buildItemResponseSchema(
         },
         additionalProperties: false,
       },
-      links: refs.schemas.paginationLinks,
+      links: refs.schemas.selfLink,
     },
   };
 }


### PR DESCRIPTION
When creating operations for single resource responses, a self link rather than paginated links object should be used in the top-level JSON API response.

Root cause behind ELK-719.