### PR TITLE
fix: allow resource IDs to be format: uri

### DIFF
--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -2,7 +2,21 @@
 
 In order to provide a consistent [API as a platform](../principles/api_program.md), Snyk APIs have additional requirements, building on [JSON API](../principles/jsonapi.md) and [Versioning](../principles/version.md) standards.
 
-## Organization and group tenants for resources
+# Resource IDs
+
+[Resource IDs] must be defined with one of the following JSON Schema formats:
+
+- `format: uuid`
+- `format: uri`
+
+UUIDs are most useful when the resource is already located by a unique UUID primary key.
+
+URIs may be better when:
+
+- The resource identity is best located by a URI. For example: [Package URLs (pURLs)](https://github.com/package-url/purl-spec).
+- Other instances where a structured, semantically-meaningful identifier provides a better experience. Vulnerabilities or issues might fall into this category.
+
+# Organization and group tenants for resources
 
 Resources in the Snyk v3 API are located under an Organization and possibly a Group tenant, specified as a path prefix.
 
@@ -603,7 +617,7 @@ The [operation](https://swagger.io/specification/#operation-object) `summary` fi
 
 ### Formats
 
-`format: uuid` and `format: date-time` are essential for indicating a field is not just a string, but actually a UUID or an RFC3339 date string. This format is relied upon by request and response validation middleware.
+`format: uri`, `format: uuid` and `format: date-time` are essential for indicating a field is not just a string, but actually a UUID or an RFC3339 date string. This format is relied upon by request and response validation middleware.
 
 Enum types (`{type: string, enum: [...]}`) should be used wherever it is possible to enumerate a closed set of valid values a field might have. This includes the set of resource types in our API.
 

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
@@ -178,7 +178,186 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid GET responses passes when status code 200 has the correct JSON body 1`] = `
+exports[`resource object rules valid GET responses passes when status code 200 has the correct JSON body identified by uri 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API data property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "self links",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid get / post response data schema",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "",
+        "statusCode": "200",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/example response 200",
+  },
+]
+`;
+
+exports[`resource object rules valid GET responses passes when status code 200 has the correct JSON body identified by uuid 1`] = `
 Array [
   Object {
     "change": Object {
@@ -581,7 +760,231 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body 1`] = `
+exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body identified by uri 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#crud-updating-responses",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response data for patch",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API type property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "self links",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid patch response data schema",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "",
+        "statusCode": "200",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "PATCH /api/example response 200",
+  },
+]
+`;
+
+exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body identified by uuid 1`] = `
 Array [
   Object {
     "change": Object {
@@ -1253,7 +1656,225 @@ Array [
 ]
 `;
 
-exports[`resource object rules valid POST responses passes when status code 201 has the correct headers and body 1`] = `
+exports[`resource object rules valid POST responses passes when status code 201 has the correct headers and body identified by uri 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API data property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "POST /api/example response 201 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "self links",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "POST /api/example response 201 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid get / post response data schema",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "POST /api/example response 201 response body: application/vnd.api+json",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "",
+        "statusCode": "201",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "POST /api/example response 201",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "description": "",
+        "statusCode": "201",
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "location header",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "POST /api/example response 201",
+  },
+]
+`;
+
+exports[`resource object rules valid POST responses passes when status code 201 has the correct headers and body identified by uuid 1`] = `
 Array [
   Object {
     "change": Object {

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -7,34 +7,37 @@ const baseJson = TestHelpers.createEmptySpec();
 
 describe("resource object rules", () => {
   describe("valid PATCH requests", () => {
-    test("passes when PATCH request body is of the correct form", () => {
-      const afterJson = {
-        ...baseJson,
-        paths: {
-          "/api/example/{example_id}": {
-            patch: {
-              responses: {}, // not tested here
-              requestBody: {
-                content: {
-                  "application/vnd.api+json": {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        data: {
-                          type: "object",
-                          properties: {
-                            id: {
-                              type: "string",
-                              format: "uuid",
-                            },
-                            type: {
-                              type: "string",
-                            },
-                            attributes: {
-                              type: "object",
-                              properties: {
-                                something: {
-                                  type: "string",
+    test.each(["uuid", "uri"])(
+      "passes when PATCH request body is of the correct form identified by %s",
+      (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/{example_id}": {
+              patch: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "object",
+                            properties: {
+                              id: {
+                                type: "string",
+                                format: format,
+                              },
+                              type: {
+                                type: "string",
+                              },
+                              attributes: {
+                                type: "object",
+                                properties: {
+                                  something: {
+                                    type: "string",
+                                  },
                                 },
                               },
                             },
@@ -47,18 +50,18 @@ describe("resource object rules", () => {
               },
             },
           },
-        },
-      } as OpenAPIV3.Document;
+        } as OpenAPIV3.Document;
 
-      const ruleRunner = new RuleRunner([resourceObjectRules]);
-      const ruleInputs = {
-        ...TestHelpers.createRuleInputs(baseJson, afterJson),
-        context,
-      };
-      const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(true);
-    });
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
   });
 
   describe("valid POST requests", () => {
@@ -432,36 +435,39 @@ describe("resource object rules", () => {
   });
 
   describe("valid GET responses", () => {
-    test("passes when status code 200 has the correct JSON body", () => {
-      const afterJson = {
-        ...baseJson,
-        paths: {
-          "/api/example": {
-            get: {
-              responses: {
-                "200": {
-                  description: "",
-                  content: {
-                    "application/vnd.api+json": {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          data: {
-                            type: "object",
-                            properties: {
-                              id: {
-                                type: "string",
-                                format: "uuid",
-                              },
-                              type: {
-                                type: "string",
+    test.each(["uuid", "uri"])(
+      "passes when status code 200 has the correct JSON body identified by %s",
+      (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example": {
+              get: {
+                responses: {
+                  "200": {
+                    description: "",
+                    content: {
+                      "application/vnd.api+json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            data: {
+                              type: "object",
+                              properties: {
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                                type: {
+                                  type: "string",
+                                },
                               },
                             },
-                          },
-                          links: {
-                            properties: {
-                              self: {
-                                type: "string",
+                            links: {
+                              properties: {
+                                self: {
+                                  type: "string",
+                                },
                               },
                             },
                           },
@@ -473,56 +479,59 @@ describe("resource object rules", () => {
               },
             },
           },
-        },
-      } as OpenAPIV3.Document;
+        } as OpenAPIV3.Document;
 
-      const ruleRunner = new RuleRunner([resourceObjectRules]);
-      const ruleInputs = {
-        ...TestHelpers.createRuleInputs(baseJson, afterJson),
-        context,
-      };
-      const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(true);
-      expect(results).toMatchSnapshot();
-    });
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+        expect(results).toMatchSnapshot();
+      },
+    );
   });
 
   describe("valid POST responses", () => {
-    test("passes when status code 201 has the correct headers and body", () => {
-      const afterJson = {
-        ...baseJson,
-        paths: {
-          "/api/example": {
-            post: {
-              responses: {
-                "201": {
-                  description: "",
-                  headers: {
-                    location: {},
-                  },
-                  content: {
-                    "application/vnd.api+json": {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          data: {
-                            type: "object",
-                            properties: {
-                              id: {
-                                type: "string",
-                                format: "uuid",
-                              },
-                              type: {
-                                type: "string",
+    test.each(["uuid", "uri"])(
+      "passes when status code 201 has the correct headers and body identified by %s",
+      (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example": {
+              post: {
+                responses: {
+                  "201": {
+                    description: "",
+                    headers: {
+                      location: {},
+                    },
+                    content: {
+                      "application/vnd.api+json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            data: {
+                              type: "object",
+                              properties: {
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                                type: {
+                                  type: "string",
+                                },
                               },
                             },
-                          },
 
-                          links: {
-                            properties: {
-                              self: {
-                                type: "string",
+                            links: {
+                              properties: {
+                                self: {
+                                  type: "string",
+                                },
                               },
                             },
                           },
@@ -534,55 +543,58 @@ describe("resource object rules", () => {
               },
             },
           },
-        },
-      } as OpenAPIV3.Document;
+        } as OpenAPIV3.Document;
 
-      const ruleRunner = new RuleRunner([resourceObjectRules]);
-      const ruleInputs = {
-        ...TestHelpers.createRuleInputs(baseJson, afterJson),
-        context,
-      };
-      const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(true);
-      expect(results).toMatchSnapshot();
-    });
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+        expect(results).toMatchSnapshot();
+      },
+    );
   });
 
   describe("valid PATCH responses", () => {
-    test("passes when status code 200 has the correct body", () => {
-      const afterJson = {
-        ...baseJson,
-        paths: {
-          "/api/example": {
-            patch: {
-              responses: {
-                "200": {
-                  description: "",
-                  content: {
-                    "application/vnd.api+json": {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          data: {
-                            type: "object",
-                            properties: {
-                              id: {
-                                type: "string",
-                                format: "uuid",
-                              },
-                              type: {
-                                type: "string",
+    test.each(["uuid", "uri"])(
+      "passes when status code 200 has the correct body identified by %s",
+      (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example": {
+              patch: {
+                responses: {
+                  "200": {
+                    description: "",
+                    content: {
+                      "application/vnd.api+json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            data: {
+                              type: "object",
+                              properties: {
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                                type: {
+                                  type: "string",
+                                },
                               },
                             },
-                          },
-                          jsonapi: {
-                            type: "string",
-                          },
-                          links: {
-                            properties: {
-                              self: {
-                                type: "string",
+                            jsonapi: {
+                              type: "string",
+                            },
+                            links: {
+                              properties: {
+                                self: {
+                                  type: "string",
+                                },
                               },
                             },
                           },
@@ -594,19 +606,19 @@ describe("resource object rules", () => {
               },
             },
           },
-        },
-      } as OpenAPIV3.Document;
+        } as OpenAPIV3.Document;
 
-      const ruleRunner = new RuleRunner([resourceObjectRules]);
-      const ruleInputs = {
-        ...TestHelpers.createRuleInputs(baseJson, afterJson),
-        context,
-      };
-      const results = ruleRunner.runRulesWithFacts(ruleInputs);
-      expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(true);
-      expect(results).toMatchSnapshot();
-    });
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+        expect(results).toMatchSnapshot();
+      },
+    );
 
     test.each([true, false])(
       "passes when status code 200 has the correct body, meta only, singleton=%s",

--- a/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
@@ -5,9 +5,14 @@ import {
   ResponseBodyRule,
   RequestRule,
   Matchers,
+  Matcher,
 } from "@useoptic/rulesets-base";
 import { links } from "../../../../docs";
 import { isOpenApiPath, isSingletonPath } from "../utils";
+
+const resourceIDFormat = new Matcher((value: any): boolean => {
+  return value === "uuid" || value === "uri";
+});
 
 const matchPatchRequest = {
   data: {
@@ -15,7 +20,7 @@ const matchPatchRequest = {
     properties: {
       id: {
         type: "string",
-        format: "uuid",
+        format: resourceIDFormat,
       },
       type: {
         type: Matchers.string,
@@ -326,7 +331,7 @@ const getPostResponseDataSchema = new ResponseBodyRule({
                 properties: {
                   id: {
                     type: "string",
-                    format: "uuid",
+                    format: resourceIDFormat,
                   },
                   type: {
                     type: "string",
@@ -344,7 +349,7 @@ const getPostResponseDataSchema = new ResponseBodyRule({
               properties: {
                 id: {
                   type: "string",
-                  format: "uuid",
+                  format: resourceIDFormat,
                 },
                 type: {
                   type: "string",
@@ -423,7 +428,7 @@ const patchResponseDataSchema = new ResponseBodyRule({
               properties: {
                 id: {
                   type: "string",
-                  format: "uuid",
+                  format: resourceIDFormat,
                 },
                 type: {
                   type: "string",


### PR DESCRIPTION
Some resources are uniquely located by a structured identifier, and do not have a UUID. Examples include packages (identified by a pURL), issues, and CVEs.

For IDs which are not UUIDs, allow the use of a URI to identify the resource. Even if the URI is of a custom type, requiring a URI creates the right incentive to define a well-formed structure for that identifier.