### PR TITLE
feat: lower pagination limit to 1

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -326,10 +326,9 @@ parameters:
     example: 10
     schema:
       type: integer
-      minimum: 10
+      minimum: 1
       maximum: 100
       default: 10
-      multipleOf: 10
       format: int32
 
   Version:

--- a/docs/principles/jsonapi.md
+++ b/docs/principles/jsonapi.md
@@ -213,7 +213,7 @@ Our API uses these reserved parameters for pagination:
 
 - `starting_after` - Return `limit` records after the record identified by cursor position `starting_after`.
 - `ending_before` - Return `limit` records before the record identified by cursor position `ending_before`.
-- `limit` - Size of page, in increments of 10, up to 100
+- `limit` - Size of page, in increments of 1, up to 100
 
 Cursor position identifiers are determined by the links given in a paginated response.
 


### PR DESCRIPTION
Hi team 👋🏻 

I have an usecase where I want to retrieve only the latest created item of a collection, sorted by creation date. 
The current Limit specification does not actually allow us to fetch only one item.
I do think that it could make a lot of sense to allow that.

Also, I removed the `multipleOf: 10`, not sure if this is compatible with `limit=1`.