### PR TITLE
fix: allow 200 responses for POST requests

### DIFF
--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/status-code-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/status-code-rules.test.ts.snap
@@ -118,7 +118,7 @@ exports[`status code rules fails when an invalid batch post request is specified
     },
     "condition": undefined,
     "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#status-codes",
-    "error": "expected POST response to only support 201, not 204",
+    "error": "expected POST response to only support status code(s) {200,201}, not 204",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
@@ -182,13 +182,13 @@ exports[`status code rules fails when an invalid post 2xx code is specified 1`] 
     "change": {
       "added": {
         "description": "i am not valid",
-        "statusCode": "200",
+        "statusCode": "204",
       },
       "changeType": "added",
       "location": {
         "conceptualLocation": {
           "inResponse": {
-            "statusCode": "200",
+            "statusCode": "204",
           },
           "method": "post",
           "path": "/api/users/{user_id}",
@@ -198,15 +198,15 @@ exports[`status code rules fails when an invalid post 2xx code is specified 1`] 
           "/api/users/{}",
           "post",
           "responses",
-          "200",
+          "204",
         ],
-        "jsonPath": "/paths/~1api~1users~1{user_id}/post/responses/200",
+        "jsonPath": "/paths/~1api~1users~1{user_id}/post/responses/204",
         "kind": "response",
       },
     },
     "condition": undefined,
     "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#status-codes",
-    "error": "expected POST response to only support 201, not 200",
+    "error": "expected POST response to only support status code(s) {200,201}, not 204",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
@@ -215,7 +215,7 @@ exports[`status code rules fails when an invalid post 2xx code is specified 1`] 
     "passed": false,
     "received": undefined,
     "type": "added",
-    "where": "POST /api/users/{user_id} response 200",
+    "where": "POST /api/users/{user_id} response 204",
   },
 ]
 `;

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/status-code-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/status-code-rules.test.ts
@@ -83,7 +83,7 @@ describe("status code rules", () => {
         "/api/users/{user_id}": {
           post: {
             responses: {
-              "200": {
+              "204": {
                 description: "i am not valid",
                 content: {
                   "application/vnd.api+json": {
@@ -248,7 +248,8 @@ describe("status code rules", () => {
     expect(results.filter((result) => !result.passed)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          error: "expected POST response to only support 201, not 204",
+          error:
+            "expected POST response to only support status code(s) {200,201}, not 204",
         }),
       ]),
     );

--- a/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
@@ -8,7 +8,7 @@ import {
   Matcher,
 } from "@useoptic/rulesets-base";
 import { links } from "../../../../docs";
-import { isOpenApiPath, isSingletonPath } from "../utils";
+import { isOpenApiPath, isSingletonPath, validPost2xxCodes } from "../utils";
 
 const resourceIDFormat = new Matcher((value: any): boolean => {
   return value === "uuid" || value === "uri";
@@ -298,7 +298,7 @@ const locationHeader = new ResponseRule({
   name: "location header",
   matches: (responseBody, rulesContext) =>
     rulesContext.operation.method === "post" &&
-    responseBody.statusCode === "201",
+    validPost2xxCodes.includes(responseBody.statusCode),
   rule: (responseAssertions) => {
     responseAssertions.added.hasResponseHeaderMatching("location", {});
     responseAssertions.changed.hasResponseHeaderMatching("location", {});

--- a/src/rulesets/rest/2022-05-25/json-api-rules/status-code-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/status-code-rules.ts
@@ -1,6 +1,10 @@
 import { Ruleset, RuleError, ResponseRule } from "@useoptic/rulesets-base";
 import { links } from "../../../../docs";
-import { isOpenApiPath, isBatchPostOperation } from "../utils";
+import {
+  isOpenApiPath,
+  isBatchPostOperation,
+  validPost2xxCodes,
+} from "../utils";
 
 const valid4xxCodes = new ResponseRule({
   name: "valid 4xx status codes",
@@ -69,13 +73,14 @@ const post2xxCodes = new ResponseRule({
     response.statusCode.startsWith("2") &&
     rulesContext.operation.method === "post",
   rule: (responseAssertions) => {
-    const validPost2xxCodes = ["201"];
     responseAssertions.added(
       "support the correct 2xx status codes",
       (response) => {
         if (!validPost2xxCodes.includes(response.statusCode)) {
           throw new RuleError({
-            message: `expected POST response to only support 201, not ${response.statusCode}`,
+            message: `expected POST response to only support status code(s) {${validPost2xxCodes.toString()}}, not ${
+              response.statusCode
+            }`,
           });
         }
       },
@@ -86,7 +91,9 @@ const post2xxCodes = new ResponseRule({
       (beforeResponse, response) => {
         if (!validPost2xxCodes.includes(response.statusCode)) {
           throw new RuleError({
-            message: `expected POST response to only support 201, not ${response.statusCode}`,
+            message: `expected POST response to only support status code(s) {${validPost2xxCodes.toString()}}, not ${
+              response.statusCode
+            }`,
           });
         }
       },

--- a/src/rulesets/rest/2022-05-25/utils.ts
+++ b/src/rulesets/rest/2022-05-25/utils.ts
@@ -111,3 +111,5 @@ export const isFullyTypedType = (type: OpenAPIV3.SchemaObject): boolean => {
   // least the top-level type
   return true;
 };
+
+export const validPost2xxCodes = ["200", "201"];


### PR DESCRIPTION
This PR allows for 200 response code for POST requests.

Context: https://snyk.slack.com/archives/C0141L0RUGJ/p1671033409502299?thread_ts=1670777230.330959&cid=C0141L0RUGJ

https://snyksec.atlassian.net/jira/software/c/projects/SOUL/boards/397?selectedIssue=SOUL-812