### PR TITLE
feat: upgrade Optic from 0.35.8 -> 0.36.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@useoptic/openapi-io": "0.35.8",
     "@useoptic/openapi-utilities": "0.35.8",
     "@useoptic/optic-ci": "0.35.8",
-    "@useoptic/rulesets-base": "0.35.8",
+    "@useoptic/rulesets-base": "0.36.5",
     "chai": "^4.3.4",
     "chalk": "^4.0.0",
     "change-case": "^4.1.2",


### PR DESCRIPTION
0.35.8 was never re-released in sweater-comb 1.23.3, due to semantic versioning. This will fix that and bump to latest.