### PR TITLE
fix: align query version format with vervet

### DIFF
--- a/components/common.yaml
+++ b/components/common.yaml
@@ -213,12 +213,12 @@ schemas:
   QueryVersion:
     type: "string"
     description: "Requested API version"
-    pattern: "^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$"
+    pattern: "^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$"
 
   ActualVersion:
     type: string
     description: Resolved API version
-    pattern: "^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$"
+    pattern: "^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$"
 
 headers:
 

--- a/docs/principles/version.md
+++ b/docs/principles/version.md
@@ -139,14 +139,6 @@ GET /path/to/resource?version=2021-09-21
 
 would match only resource versions released as GA, as of 2021-09-21.
 
-As a shortcut, you can also request "today's latest experimental" with:
-
-```json
-GET /path/to/resource?version=experimental
-```
-
-Developing against a "floating version" like this would not be recommended, but it can be a useful way to discover new development.
-
 ## Versioning in requests and responses
 
 With the concept of versioning established, requests and responses must support certain parameters and headers related to versioning.
@@ -179,8 +171,6 @@ Using the `?version=` parameter, clients may choose to interact with any release
 To release a stable application, choose an announced GA release date, and be assured that the API will not change for at least 180 days past the following GA release.
 
 To evaluate a recent beta feature, you might pin your version date at "yesterday" and use that with `~beta`. Keep that version date pinned at the date you started with, until you're ready to evaluate or support a newer release of the API.
-
-To browse the latest experimental changes, you might request the OpenAPI specification for `?version=experimental`. However, floating versions should never be used in client code.
 
 Clients must be developed against (or generated from) a pinned version of the API declaring a fixed _YYYY-mm-dd_ release date. Otherwise the client may fail in unexpected ways, possibly with undefined behavior when new versions of the API are released.
 

--- a/end-end-tests/api-standards/versions/2021-09-06~beta/spec-baseline.yaml
+++ b/end-end-tests/api-standards/versions/2021-09-06~beta/spec-baseline.yaml
@@ -230,7 +230,7 @@ components:
   schemas:
     ActualVersion:
       description: Resolved API version
-      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     Error:
       additionalProperties: false
@@ -373,7 +373,7 @@ components:
       type: object
     QueryVersion:
       description: Requested API version
-      pattern: ^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     SelfLink:
       additionalProperties: false

--- a/end-end-tests/api-standards/versions/2021-09-06~beta/spec-remove-get-sunset-2022-01-05.yaml
+++ b/end-end-tests/api-standards/versions/2021-09-06~beta/spec-remove-get-sunset-2022-01-05.yaml
@@ -230,7 +230,7 @@ components:
   schemas:
     ActualVersion:
       description: Resolved API version
-      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     Error:
       additionalProperties: false
@@ -373,7 +373,7 @@ components:
       type: object
     QueryVersion:
       description: Requested API version
-      pattern: ^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     SelfLink:
       additionalProperties: false

--- a/end-end-tests/api-standards/versions/2021-09-06~experimental/spec-baseline-fail-no-openapi.yaml
+++ b/end-end-tests/api-standards/versions/2021-09-06~experimental/spec-baseline-fail-no-openapi.yaml
@@ -230,7 +230,7 @@ components:
   schemas:
     ActualVersion:
       description: Resolved API version
-      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     Error:
       additionalProperties: false
@@ -373,7 +373,7 @@ components:
       type: object
     QueryVersion:
       description: Requested API version
-      pattern: ^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     SelfLink:
       additionalProperties: false

--- a/end-end-tests/api-standards/versions/2021-09-06~experimental/spec-baseline.yaml
+++ b/end-end-tests/api-standards/versions/2021-09-06~experimental/spec-baseline.yaml
@@ -230,7 +230,7 @@ components:
   schemas:
     ActualVersion:
       description: Resolved API version
-      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     Error:
       additionalProperties: false
@@ -373,7 +373,7 @@ components:
       type: object
     QueryVersion:
       description: Requested API version
-      pattern: ^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     SelfLink:
       additionalProperties: false

--- a/end-end-tests/api-standards/versions/2021-10-06~beta/spec-baseline.yaml
+++ b/end-end-tests/api-standards/versions/2021-10-06~beta/spec-baseline.yaml
@@ -229,7 +229,7 @@ components:
   schemas:
     ActualVersion:
       description: Resolved API version
-      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     Error:
       additionalProperties: false
@@ -372,7 +372,7 @@ components:
       type: object
     QueryVersion:
       description: Requested API version
-      pattern: ^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     SelfLink:
       additionalProperties: false

--- a/end-end-tests/api-standards/versions/2021-10-06~experimental/spec.yaml
+++ b/end-end-tests/api-standards/versions/2021-10-06~experimental/spec.yaml
@@ -229,7 +229,7 @@ components:
   schemas:
     ActualVersion:
       description: Resolved API version
-      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     Error:
       additionalProperties: false
@@ -372,7 +372,7 @@ components:
       type: object
     QueryVersion:
       description: Requested API version
-      pattern: ^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$
+      pattern: ^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$
       type: string
     SelfLink:
       additionalProperties: false

--- a/src/woollypully/__tests__/fake-service/versions/2022-05-23~beta/spec.json
+++ b/src/woollypully/__tests__/fake-service/versions/2022-05-23~beta/spec.json
@@ -312,7 +312,7 @@
     "schemas": {
       "ActualVersion": {
         "description": "Resolved API version",
-        "pattern": "^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?)$",
+        "pattern": "^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$",
         "type": "string"
       },
       "Error": {
@@ -484,7 +484,7 @@
       },
       "QueryVersion": {
         "description": "Requested API version",
-        "pattern": "^(wip|work-in-progress|experimental|beta|((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|work-in-progress|experimental|beta))?))$",
+        "pattern": "^((([0-9]{4})-([0-1][0-9]))-((3[01])|(0[1-9])|([12][0-9]))(~(wip|experimental|beta|ga))?)$",
         "type": "string"
       },
       "RepoAttributes": {


### PR DESCRIPTION
Vervet, which is used by backends to vet query versions, does:
- accept "ga" as stability
- not accept query versions without a date
- not accept "work-in-progress" as stability