### PR TITLE
feat: add rules for POST/PATCH/DELETE on relationships

### DIFF
--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
@@ -45,7 +45,7 @@ exports[`resource object rules invalid PATCH responses fails when content is spe
 ]
 `;
 
-exports[`resource object rules valid DELETE responses passes when status code 200 has the correct body 1`] = `
+exports[`resource object rules valid DELETE responses passes when status code 200 has the correct body (jsonapi/meta fields in content) 1`] = `
 [
   {
     "change": {
@@ -548,7 +548,7 @@ exports[`resource object rules valid GET responses passes when status code 200 h
 ]
 `;
 
-exports[`resource object rules valid PATCH responses passes when singleton status code 200 has the correct body 1`] = `
+exports[`resource object rules valid PATCH responses passes when singleton status code 200 has the correct body (data is a single resource object) 1`] = `
 [
   {
     "change": {

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
@@ -132,7 +132,7 @@ exports[`resource object rules valid DELETE responses passes when status code 20
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "valid patch response data schema",
+    "name": "valid delete response data schema",
     "passed": true,
     "received": undefined,
     "severity": 2,

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/status-code-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/status-code-rules.test.ts.snap
@@ -225,6 +225,51 @@ exports[`status code rules fails when an invalid post 2xx code is specified 1`] 
 ]
 `;
 
+exports[`status code rules fails when an invalid relationship post request is specified 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "description": "invalid :'(",
+        "statusCode": "206",
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "206",
+          },
+          "method": "post",
+          "path": "/api/users/{user_id}/relationships",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users/{}/relationships",
+          "post",
+          "responses",
+          "206",
+        ],
+        "jsonPath": "/paths/~1api~1users~1{user_id}~1relationships/post/responses/206",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#status-codes",
+    "error": "expected relationship POST response to only support status code(s) {200,201,204}, not 206",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid 2xx status codes for relationship post",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/users/{user_id}/relationships response 206",
+  },
+]
+`;
+
 exports[`status code rules passes for a valid batch post 204 code 1`] = `
 [
   {
@@ -266,6 +311,51 @@ exports[`status code rules passes for a valid batch post 204 code 1`] = `
     "severity": 2,
     "type": "added",
     "where": "POST /api/users response 204",
+  },
+]
+`;
+
+exports[`status code rules passes for a valid relationship post 200 code 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "description": "got it",
+        "statusCode": "200",
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "post",
+          "path": "/api/users/{user_id}/relationships/somethings",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users/{}/relationships/somethings",
+          "post",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users~1{user_id}~1relationships~1somethings/post/responses/200",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#status-codes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid 2xx status codes for relationship post",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/users/{user_id}/relationships/somethings response 200",
   },
 ]
 `;

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -173,6 +173,47 @@ describe("resource object rules", () => {
       expect(results.every((result) => result.passed)).toBe(true);
     });
 
+    test("passes when POST request body for a relationship is of the correct form", async () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example/relationships/example": {
+            post: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(true);
+    });
+
     test("passes when bulk POST request body is of the correct form", async () => {
       const afterJson = {
         ...baseJson,

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -123,7 +123,7 @@ describe("resource object rules", () => {
     );
 
     test.each(["uuid", "uri"])(
-      "passes when PATCH request body for a relationship is of the correct form",
+      "passes when PATCH request body for a relationship is of the correct form (data is an collection of resource objects with id and type)",
       async (format) => {
         const afterJson = {
           ...baseJson,
@@ -173,7 +173,7 @@ describe("resource object rules", () => {
       },
     );
 
-    test("fails when PATCH request body for a relationship is of incorrect form", async () => {
+    test("fails when PATCH request body for a relationship is of incorrect form (missing id from collection of resource objects in data)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -229,7 +229,7 @@ describe("resource object rules", () => {
   });
 
   describe("valid POST requests", () => {
-    test("passes when POST request body is of the correct form", async () => {
+    test("passes when POST request body is of the correct form (data is a single object with type, attributes)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -279,7 +279,7 @@ describe("resource object rules", () => {
     });
 
     test.each(["uuid", "uri"])(
-      "passes when POST request body for a relationship is of the correct form",
+      "passes when POST request body for a relationship is of the correct form (data is collection of resource objects with type and id)",
       async (format) => {
         const afterJson = {
           ...baseJson,
@@ -329,7 +329,7 @@ describe("resource object rules", () => {
       },
     );
 
-    test("fails when POST request body for a relationship is of incorrect form", async () => {
+    test("fails when POST request body for a relationship is of incorrect form (missing id from resource objects in data array)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -383,7 +383,7 @@ describe("resource object rules", () => {
       );
     });
 
-    test("passes when bulk POST request body is of the correct form", async () => {
+    test("passes when bulk POST request body is of the correct form (data is an collection of resource objects with type and attributes)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -442,7 +442,7 @@ describe("resource object rules", () => {
   });
 
   describe("invalid PATCH requests", () => {
-    test("fails when PATCH request body is not of the correct form", async () => {
+    test("fails when PATCH request body is not of the correct form (data is missing required fields attributes/type)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -490,7 +490,7 @@ describe("resource object rules", () => {
   });
 
   describe("invalid POST requests", () => {
-    test("fails when POST request body is not of the correct form", async () => {
+    test("fails when POST request body is not of the correct form (missing required fields attributes/type)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -535,7 +535,7 @@ describe("resource object rules", () => {
       );
     });
 
-    test("fails when bulk POST request body is not the correct form", async () => {
+    test("fails when bulk POST request body is not the correct form (bulk post data should be collection of resource objects)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -584,7 +584,7 @@ describe("resource object rules", () => {
       );
     });
 
-    test("fails when bulk POST request array elements are not of the correct form", async () => {
+    test("fails when bulk POST request array elements are not of the correct form (missing required fields type/attributes)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -947,7 +947,7 @@ describe("resource object rules", () => {
       },
     );
 
-    test("passes when singleton status code 200 has the correct body", async () => {
+    test("passes when singleton status code 200 has the correct body (data is a single resource object)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -1004,7 +1004,7 @@ describe("resource object rules", () => {
   });
 
   describe("valid DELETE responses", () => {
-    test("passes when status code 200 has the correct body", async () => {
+    test("passes when status code 200 has the correct body (jsonapi/meta fields in content)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -1047,7 +1047,7 @@ describe("resource object rules", () => {
     });
 
     test.each(["uuid", "uri"])(
-      "passes when DELETE request body for a relationship is of the correct form",
+      "passes when DELETE request body for a relationship is of the correct form (data is collection of resource objects)",
       async (format) => {
         const afterJson = {
           ...baseJson,
@@ -1097,7 +1097,7 @@ describe("resource object rules", () => {
       },
     );
 
-    test("fails when DELETE request body for a relationship is of incorrect form", async () => {
+    test("fails when DELETE request body for a relationship is of incorrect form (resource objects in collection missing id)", async () => {
       const afterJson = {
         ...baseJson,
         paths: {

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -121,6 +121,111 @@ describe("resource object rules", () => {
         expect(results.every((result) => result.passed)).toBe(true);
       },
     );
+
+    test.each(["uuid", "uri"])(
+      "passes when PATCH request body for a relationship is of the correct form",
+      async (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/relationships/example": {
+              patch: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                },
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
+
+    test("fails when PATCH request body for a relationship is of incorrect form", async () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example/relationships/example": {
+            patch: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              // Should have an id here.
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where:
+              "PATCH /api/example/relationships/example request body: application/vnd.api+json",
+            name: "request body for relationship post/patch/delete",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
+    });
   });
 
   describe("valid POST requests", () => {
@@ -173,7 +278,58 @@ describe("resource object rules", () => {
       expect(results.every((result) => result.passed)).toBe(true);
     });
 
-    test("passes when POST request body for a relationship is of the correct form", async () => {
+    test.each(["uuid", "uri"])(
+      "passes when POST request body for a relationship is of the correct form",
+      async (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/relationships/example": {
+              post: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                },
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
+
+    test("fails when POST request body for a relationship is of incorrect form", async () => {
       const afterJson = {
         ...baseJson,
         paths: {
@@ -187,10 +343,14 @@ describe("resource object rules", () => {
                       type: "object",
                       properties: {
                         data: {
-                          type: "object",
-                          properties: {
-                            type: {
-                              type: "string",
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              // Should have an id here.
                             },
                           },
                         },
@@ -211,7 +371,16 @@ describe("resource object rules", () => {
       };
       const results = await ruleRunner.runRulesWithFacts(ruleInputs);
       expect(results.length).toBeGreaterThan(0);
-      expect(results.every((result) => result.passed)).toBe(true);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where:
+              "POST /api/example/relationships/example request body: application/vnd.api+json",
+            name: "request body for relationship post/patch/delete",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
     });
 
     test("passes when bulk POST request body is of the correct form", async () => {
@@ -875,6 +1044,111 @@ describe("resource object rules", () => {
       expect(results.length).toBeGreaterThan(0);
       expect(results.every((result) => result.passed)).toBe(true);
       expect(results).toMatchSnapshot();
+    });
+
+    test.each(["uuid", "uri"])(
+      "passes when DELETE request body for a relationship is of the correct form",
+      async (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/relationships/example": {
+              delete: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                },
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
+
+    test("fails when DELETE request body for a relationship is of incorrect form", async () => {
+      const afterJson = {
+        ...baseJson,
+        paths: {
+          "/api/example/relationships/example": {
+            delete: {
+              responses: {}, // not tested here
+              requestBody: {
+                content: {
+                  "application/vnd.api+json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              // Should have an id here.
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+
+      const ruleRunner = new RuleRunner([resourceObjectRules]);
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(baseJson, afterJson),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            where:
+              "DELETE /api/example/relationships/example request body: application/vnd.api+json",
+            name: "request body for relationship post/patch/delete",
+            error: "Expected a partial match",
+          }),
+        ]),
+      );
     });
   });
 

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/status-code-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/status-code-rules.test.ts
@@ -304,4 +304,109 @@ describe("status code rules", () => {
     expect(results.every((result) => result.passed)).toBe(true);
     expect(results).toMatchSnapshot();
   });
+
+  test("fails when an invalid relationship post request is specified", async () => {
+    const afterJson = {
+      ...baseJson,
+      paths: {
+        "/api/users/{user_id}/relationships": {
+          post: {
+            requestBody: {
+              content: {
+                "application/vnd.api+json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            id: "some-id",
+                            type: "some-type",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              "206": {
+                description: "invalid :'(",
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+
+    const ruleRunner = new RuleRunner([statusCodesRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, afterJson),
+      context,
+    };
+    const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toBeGreaterThan(0);
+
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results.filter((result) => !result.passed)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          error:
+            "expected relationship POST response to only support status code(s) {200,201,204}, not 206",
+        }),
+      ]),
+    );
+    expect(results).toMatchSnapshot();
+  });
+
+  test("passes for a valid relationship post 200 code", async () => {
+    const afterJson = {
+      ...baseJson,
+      paths: {
+        "/api/users/{user_id}/relationships/somethings": {
+          post: {
+            requestBody: {
+              content: {
+                "application/vnd.api+json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            id: "some-id",
+                            type: "some-type",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              "200": {
+                description: "got it",
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+
+    const ruleRunner = new RuleRunner([statusCodesRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, afterJson),
+      context,
+    };
+    const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(true);
+    expect(results).toMatchSnapshot();
+  });
 });

--- a/src/rulesets/rest/2022-05-25/utils.ts
+++ b/src/rulesets/rest/2022-05-25/utils.ts
@@ -1,6 +1,12 @@
 import { Field, RuleContext } from "@useoptic/rulesets-base";
 import { OpenAPIV3 } from "@useoptic/openapi-utilities";
 
+/**
+ * isRelationshipPath evaluates whether the given path is a JSONAPI relationships path,
+ * either containing /relationships/ or ending with /relationships.
+ */
+export const isRelationshipPath = (path: string) =>
+  /\/relationships\/|\/relationships$/.test(path);
 export const isOpenApiPath = (path: string) => /\/openapi/.test(path);
 export const isSingletonPath = (rulesContext: RuleContext) =>
   !!rulesContext.specification.raw.paths[rulesContext.operation.path]?.[


### PR DESCRIPTION
This adds:
 - Request data rules for `POST`/`PATCH`/`DELETE` requests on `/relationships/` paths.
 - A specific status code rule for `POST` relationship requests, in an effort to avoid overloading either of the existing `POST` status code rules.

The `jsonapi` spec [distinguishes](https://jsonapi.org/format/#crud-updating-resource-relationships) modifications to a resource's relationships from modifications to the resource itself, with different request data requirements. Namely, `attributes` are not required but an `id` is always required.