### PR TITLE
chore: add support for secret scanning in CI chore: add supprot for secret scanning using pre-commit hooks chore: ignore false positives after 1st secret scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,10 @@
 version: 2.1
 
 orbs:
-  snyk: snyk/snyk@1.4.0
+  snyk: snyk/snyk@1.7.0
+  prodsec: snyk/prodsec-orb@1.0
 
+ 
 defaults: &defaults
   resource_class: small
   docker:
@@ -135,6 +137,12 @@ workflows:
   version: 2
   test_and_publish:
     jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: snyk-on-snyk-extensibility
+
       - scan:
           name: Snyk Vuln Scan
           context:

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,8 @@
+717240ec377e62902498e5c247059f24610ee0e3:.swm/rest.m09xr.sw.md:generic-api-key:441
+bcb88b2efeb56fabf49ccf4223d26cee3ec740e5:docs/standards/rest.md:generic-api-key:308
+6080cd9822cf856958e2c1318448d3578bbcdfdd:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:2111
+2b0351e5da078cf03863cb925e4493cd8d6da2e9:src/rulesets-new/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:1413
+2b0351e5da078cf03863cb925e4493cd8d6da2e9:src/rulesets-new/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:1487
+2b0351e5da078cf03863cb925e4493cd8d6da2e9:src/rulesets-new/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:1508
+8a2b8ab2e093291735418a8e8bee856dc8ce537c:src/rulesets/tests/__snapshots__/properties.test.ts.snap:generic-api-key:1077
+8a2b8ab2e093291735418a8e8bee856dc8ce537c:src/rulesets/tests/__snapshots__/properties.test.ts.snap:generic-api-key:1171

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
This is an example of what typical tasks are needed to add secret scanning ot your repos.
0/ install gitleaks and pre-commit on your development machine
1/ clone and update your local copy
2/ scan it with `gitleak detect -v .`
3/ asses any findings and rotate actual secret as per [secret leakage procedures](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/1562411072/Secret+Leakage+in+GitHub)

Here we only had false positives as far as I can tell (please refuse the PR if you think differently)

4/ add/update false positives to `.gitleaksignore` or remove them.
6/ add/update `.pre-commit-config.yaml`
7/ update `.circleci/config.yml` to include the `prodsec/secret-scan` as the 1st step of your pipeline(s)
8/ make a PR for someone to review and approve the change
9/ merge

Feel more confident you won't push a secret to GitHub again.

