### PR TITLE
fix: remove attributes from required post body properties

### DIFF
--- a/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
@@ -93,9 +93,6 @@ const matchPostRequest = {
       type: {
         type: Matchers.string,
       },
-      attributes: {
-        type: "object",
-      },
     },
   },
 };
@@ -176,9 +173,6 @@ const matchBulkPostRequest = {
       properties: {
         type: {
           type: Matchers.string,
-        },
-        attributes: {
-          type: "object",
         },
       },
     },


### PR DESCRIPTION
The upstream JSON:API spec states that only type is required. Requiring attributes means we will be unable to create resources that have no attributes.

An example of what this is blocking is creating app_install resources which have bodies similar to:

    {
        "type": "app_install",
        "relationships": {
            "app": { "data": { "type": "app", "id": 1234 } }
        }
    }

This is perfectly valid under JSON:API specs but fails the current linting due to the missing attributes.