### PR TITLE
fix: ship built version of package

### DIFF
--- a/scripts/build-npm.bash
+++ b/scripts/build-npm.bash
@@ -4,6 +4,7 @@ cd $(dirname $0)/..
 
 # Stage 1: clean install of dev dependencies, build TS
 npm ci
+npm run build
 npm pack
 
 # Use GH_TOKEN as a fallback if GITHUB_TOKEN is not set


### PR DESCRIPTION
When we made the switch from yarn to npm, the command to build the project was accidentally removed. As such we are currently just shipping the sources and not the built binary, so any project that consumes this will have to build it themselves.

This re-adds the build step so sweater-comb can be ran using npx again.