### PR TITLE
chore: downgrade optic 0.43.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@useoptic/json-pointer-helpers": "^0.48.4",
         "@useoptic/openapi-io": "^0.48.4",
         "@useoptic/openapi-utilities": "^0.48.9",
-        "@useoptic/optic": "^0.48.4",
+        "@useoptic/optic": "^0.43.0",
         "@useoptic/rulesets-base": "^0.48.4",
         "ajv": "^8.12.0",
         "chalk": "^4.0.0",
@@ -5575,7 +5575,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -5588,7 +5588,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "inBundle": true,
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -5597,7 +5597,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -5989,12 +5989,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.30.4.tgz",
-      "integrity": "sha512-wFuuDR+O1OAE2GL0q68h1Ty00RE6Ihcixr55A6TU5RCvOUHnwJw9LGuDVg9NxDiAp7m/YJpa+UaOuLAz0ziyOQ==",
-      "inBundle": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -8107,9 +8101,9 @@
       }
     },
     "node_modules/@useoptic/optic": {
-      "version": "0.48.8",
-      "resolved": "https://registry.npmjs.org/@useoptic/optic/-/optic-0.48.8.tgz",
-      "integrity": "sha512-K6IC1b1dDSEXHrFMaY6I7lR4Xs+r2kNza/SMXQQVlTzah1bSlVJCt2VKhQeLTgHSmzEi9KJlzRNhbZttGHHzEw==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/optic/-/optic-0.43.0.tgz",
+      "integrity": "sha512-F3CtiuCjXR86ES1LCuIAsZM48vsoYD6otX7s4LgzMijMUB+ZxdEzhVmbevXsqluOHmoSlYy4/CC1EaeQaK18Ig==",
       "inBundle": true,
       "dependencies": {
         "@babel/runtime": "^7.20.6",
@@ -8117,24 +8111,21 @@
         "@jsdevtools/ono": "^7.1.3",
         "@octokit/rest": "^19.0.0",
         "@sentry/node": "^7.10.0",
-        "@sinclair/typebox": "^0.30.0",
         "@stoplight/spectral-core": "^1.8.1",
-        "@useoptic/openapi-io": "0.48.8",
-        "@useoptic/openapi-utilities": "0.48.8",
-        "@useoptic/rulesets-base": "0.48.8",
-        "@useoptic/standard-rulesets": "0.48.8",
+        "@useoptic/openapi-io": "0.43.0",
+        "@useoptic/openapi-utilities": "0.43.0",
+        "@useoptic/rulesets-base": "0.43.0",
+        "@useoptic/standard-rulesets": "0.43.0",
         "ajv": "^8.6.0",
         "ajv-formats": "~2.1.0",
-        "analytics-node": "^6.2.0",
         "async-exit-hook": "^2.0.1",
         "axax": "^0.2.2",
         "bottleneck": "^2.19.5",
         "chalk": "^4.1.2",
-        "commander": "^11.0.0",
+        "commander": "^10.0.0",
         "conf": "^10.2.0",
         "dotenv": "^16.0.3",
         "fast-deep-equal": "^3.1.3",
-        "fast-glob": "^3.2.12",
         "fs-extra": "^11.1.0",
         "git-url-parse": "^13.1.0",
         "har-schema": "^2.0.0",
@@ -8143,26 +8134,24 @@
         "js-yaml": "^4.1.0",
         "json-schema-traverse": "^1.0.0",
         "json-stable-stringify": "^1.0.1",
-        "latest-version": "^5.1.0",
-        "lodash.chunk": "^4.2.0",
         "lodash.groupby": "^4.6.0",
         "lodash.sortby": "^4.7.0",
         "log": "^6.3.1",
         "log-node": "^8.0.3",
         "loglevel": "^1.8.0",
-        "micromatch": "^4.0.5",
-        "minimatch": "9.0.3",
-        "mockttp": "^3.9.1",
+        "minimatch": "9.0.0",
+        "mockttp": "^3.7.4",
         "node-fetch": "^2.6.7",
         "node-forge": "^1.2.1",
         "node-machine-id": "^1.1.12",
         "open": "^8.4.0",
         "ora": "5.4.1",
+        "picomatch": "^2.3.1",
         "pluralize": "8.0.0",
         "portfinder": "^1.0.28",
         "postman-collection": "^4.1.7",
         "prompts": "^2.4.2",
-        "semver": "^7.5.4",
+        "semver": "^7.3.8",
         "slice-ansi": "^4.0.0",
         "stream-chain": "^2.2.5",
         "stream-json": "^1.7.4",
@@ -8179,16 +8168,58 @@
         "optic": "build/index.js"
       }
     },
-    "node_modules/@useoptic/optic/node_modules/@useoptic/openapi-utilities": {
-      "version": "0.48.8",
-      "resolved": "https://registry.npmjs.org/@useoptic/openapi-utilities/-/openapi-utilities-0.48.8.tgz",
-      "integrity": "sha512-ZfGEeSps5nAEAkcOR9uSijWMzJaLqsxROpGXXP31X4Ebyn5qE1npRcbhsMX2GlcquQwo0CuyV8HW4eeafhR9Hw==",
+    "node_modules/@useoptic/optic/node_modules/@useoptic/json-pointer-helpers": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.43.0.tgz",
+      "integrity": "sha512-bzt8V+StHAqliJ6ClL3B25OS8lMCiVSDKwL5WjvKgG6BI6tXUEgC6v4/kONeQw7UUKlscxsQsrBI5oTgiJ6gbA==",
       "inBundle": true,
       "dependencies": {
-        "@useoptic/json-pointer-helpers": "0.48.8",
+        "jsonpointer": "^5.0.1",
+        "minimatch": "9.0.0"
+      }
+    },
+    "node_modules/@useoptic/optic/node_modules/@useoptic/openapi-io": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/openapi-io/-/openapi-io-0.43.0.tgz",
+      "integrity": "sha512-PwVU+lZepJfKnpHJNQaaG03zM68NZwLsuvqiy+wIZ9uBgJ/w6fyY6rYfF/IaeaR5FgPj36o+V6405cj7PUhQaw==",
+      "inBundle": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9",
+        "@jsdevtools/ono": "^7.1.3",
+        "@useoptic/json-pointer-helpers": "0.43.0",
+        "@useoptic/openapi-utilities": "0.43.0",
         "ajv": "^8.6.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
+        "bottleneck": "^2.19.5",
+        "chalk": "^4.1.2",
+        "fast-deep-equal": "^3.1.3",
+        "fast-json-patch": "^3.1.1",
+        "is-url": "^1.2.4",
+        "json-stable-stringify": "^1.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.sortby": "^4.7.0",
+        "node-fetch": "^2.6.7",
+        "openapi-types": "^12.0.2",
+        "semver": "^7.3.8",
+        "upath": "^2.0.1",
+        "yaml": "^2.2.0",
+        "yaml-ast-parser": "^0.0.43"
+      }
+    },
+    "node_modules/@useoptic/optic/node_modules/@useoptic/openapi-utilities": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/openapi-utilities/-/openapi-utilities-0.43.0.tgz",
+      "integrity": "sha512-DgLbsmXGZdud4XJnZe180ZS1xp7d+XOPa+4+/K2qDbGaVSTTYSYTCWGeyko64Artjb1AxZMNjM+RLO4/Znjgng==",
+      "inBundle": true,
+      "dependencies": {
+        "@octokit/rest": "^19.0.0",
+        "@sentry/node": "^7.10.0",
+        "@useoptic/json-pointer-helpers": "0.43.0",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "analytics-node": "^6.2.0",
         "chalk": "^4.1.2",
         "fast-deep-equal": "^3.1.3",
         "is-url": "^1.2.4",
@@ -8203,6 +8234,24 @@
         "yaml-ast-parser": "^0.0.43"
       }
     },
+    "node_modules/@useoptic/optic/node_modules/@useoptic/rulesets-base": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/rulesets-base/-/rulesets-base-0.43.0.tgz",
+      "integrity": "sha512-e1C03WuPZIib7CiWPojLkGvlm1x4s5vTrkllt7n1wJHhZHFWkaF6FYSj9qMwrZ3HLRCKflX6ru+Z83Vw+/cAGg==",
+      "inBundle": true,
+      "dependencies": {
+        "@stoplight/spectral-core": "^1.8.1",
+        "@stoplight/spectral-rulesets": "^1.14.1",
+        "@useoptic/json-pointer-helpers": "0.43.0",
+        "@useoptic/openapi-utilities": "0.43.0",
+        "lodash.pick": "^4.4.0",
+        "node-fetch": "^2.6.7",
+        "semver": "^7.3.8"
+      },
+      "bin": {
+        "rulesets-base": "build/index.js"
+      }
+    },
     "node_modules/@useoptic/optic/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -8210,15 +8259,6 @@
       "inBundle": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@useoptic/optic/node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-      "inBundle": true,
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@useoptic/optic/node_modules/fs-extra": {
@@ -8248,9 +8288,9 @@
       }
     },
     "node_modules/@useoptic/optic/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
       "inBundle": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8399,13 +8439,13 @@
       "inBundle": true
     },
     "node_modules/@useoptic/standard-rulesets": {
-      "version": "0.48.8",
-      "resolved": "https://registry.npmjs.org/@useoptic/standard-rulesets/-/standard-rulesets-0.48.8.tgz",
-      "integrity": "sha512-1q8HMkEtjImNkcO95lx1b0aZzVaUZ9Mp1cojDnoqpcQct4p5JlW/TEA2cHda7AuF05UDKyvRpADtiYOD6J6lzQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/standard-rulesets/-/standard-rulesets-0.43.0.tgz",
+      "integrity": "sha512-fm/OhVMakmJs89vifEqVx+3TXbFBXMRKBpBLyQuM2TIl/ym6jblw2qioQuQi0E2zlOB2vYKTmEF7kBEZxQ0QDA==",
       "inBundle": true,
       "dependencies": {
-        "@useoptic/openapi-utilities": "0.48.8",
-        "@useoptic/rulesets-base": "0.48.8",
+        "@useoptic/openapi-utilities": "0.43.0",
+        "@useoptic/rulesets-base": "0.43.0",
         "ajv": "^8.6.0",
         "ajv-formats": "~2.1.0",
         "whatwg-mimetype": "^3.0.0"
@@ -8414,16 +8454,29 @@
         "standard-rulesets": "build/index.js"
       }
     },
-    "node_modules/@useoptic/standard-rulesets/node_modules/@useoptic/openapi-utilities": {
-      "version": "0.48.8",
-      "resolved": "https://registry.npmjs.org/@useoptic/openapi-utilities/-/openapi-utilities-0.48.8.tgz",
-      "integrity": "sha512-ZfGEeSps5nAEAkcOR9uSijWMzJaLqsxROpGXXP31X4Ebyn5qE1npRcbhsMX2GlcquQwo0CuyV8HW4eeafhR9Hw==",
+    "node_modules/@useoptic/standard-rulesets/node_modules/@useoptic/json-pointer-helpers": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/json-pointer-helpers/-/json-pointer-helpers-0.43.0.tgz",
+      "integrity": "sha512-bzt8V+StHAqliJ6ClL3B25OS8lMCiVSDKwL5WjvKgG6BI6tXUEgC6v4/kONeQw7UUKlscxsQsrBI5oTgiJ6gbA==",
       "inBundle": true,
       "dependencies": {
-        "@useoptic/json-pointer-helpers": "0.48.8",
+        "jsonpointer": "^5.0.1",
+        "minimatch": "9.0.0"
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/@useoptic/openapi-utilities": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/openapi-utilities/-/openapi-utilities-0.43.0.tgz",
+      "integrity": "sha512-DgLbsmXGZdud4XJnZe180ZS1xp7d+XOPa+4+/K2qDbGaVSTTYSYTCWGeyko64Artjb1AxZMNjM+RLO4/Znjgng==",
+      "inBundle": true,
+      "dependencies": {
+        "@octokit/rest": "^19.0.0",
+        "@sentry/node": "^7.10.0",
+        "@useoptic/json-pointer-helpers": "0.43.0",
         "ajv": "^8.6.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
+        "analytics-node": "^6.2.0",
         "chalk": "^4.1.2",
         "fast-deep-equal": "^3.1.3",
         "is-url": "^1.2.4",
@@ -8437,6 +8490,101 @@
         "ts-invariant": "^0.9.3",
         "yaml-ast-parser": "^0.0.43"
       }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/@useoptic/rulesets-base": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@useoptic/rulesets-base/-/rulesets-base-0.43.0.tgz",
+      "integrity": "sha512-e1C03WuPZIib7CiWPojLkGvlm1x4s5vTrkllt7n1wJHhZHFWkaF6FYSj9qMwrZ3HLRCKflX6ru+Z83Vw+/cAGg==",
+      "inBundle": true,
+      "dependencies": {
+        "@stoplight/spectral-core": "^1.8.1",
+        "@stoplight/spectral-rulesets": "^1.14.1",
+        "@useoptic/json-pointer-helpers": "0.43.0",
+        "@useoptic/openapi-utilities": "0.43.0",
+        "lodash.pick": "^4.4.0",
+        "node-fetch": "^2.6.7",
+        "semver": "^7.3.8"
+      },
+      "bin": {
+        "rulesets-base": "build/index.js"
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "inBundle": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "inBundle": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/minimatch": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "inBundle": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "inBundle": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "inBundle": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@useoptic/standard-rulesets/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "inBundle": true
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -9771,7 +9919,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -10575,6 +10723,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
       "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "inBundle": true,
       "engines": {
         "node": ">=14"
       }
@@ -12906,7 +13055,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -13010,7 +13159,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -13104,7 +13253,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -13779,7 +13928,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -15114,7 +15263,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "inBundle": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15141,7 +15290,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -15226,7 +15375,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "inBundle": true,
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -18159,12 +18308,6 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
-    "node_modules/lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
-      "inBundle": true
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -18654,7 +18797,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "inBundle": true,
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -18672,7 +18815,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -20982,6 +21125,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20995,8 +21139,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "inBundle": true
+      ]
     },
     "node_modules/quick-format-unescaped": {
       "version": "3.0.3",
@@ -21884,7 +22027,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "inBundle": true,
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -21941,6 +22084,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21955,7 +22099,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -24135,7 +24278,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "inBundle": true,
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@useoptic/json-pointer-helpers": "^0.48.4",
     "@useoptic/openapi-io": "^0.48.4",
     "@useoptic/openapi-utilities": "^0.48.9",
-    "@useoptic/optic": "^0.48.4",
+    "@useoptic/optic": "^0.43.0",
     "@useoptic/rulesets-base": "^0.48.4",
     "ajv": "^8.12.0",
     "chalk": "^4.0.0",
@@ -92,5 +92,14 @@
       "^nimma/fallbacks$": "<rootDir>/node_modules/nimma/dist/cjs/fallbacks/index.js",
       "^nimma/legacy$": "<rootDir>/node_modules/nimma/dist/legacy/cjs/index.js"
     }
-  }
+  },
+  "bundleDependencies": [
+    "@stoplight/spectral-core",
+    "@stoplight/spectral-rulesets",
+    "@useoptic/json-pointer-helpers",
+    "@useoptic/openapi-io",
+    "@useoptic/optic",
+    "@useoptic/openapi-utilities",
+    "@useoptic/rulesets-base"
+  ]
 }


### PR DESCRIPTION
Fixes #472

I'm not sure why this fixes the problem, but I bisected and found it started with 2.1.1.

That release included an upgrade of the @useoptic/optic dependency. Reverting that upgrade seemed to fix the problem.

There's likely an Optic bug here to follow up on, but this unblocks us in the meantime.