### PR TITLE
fix: add nix result to path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,15 +11,23 @@
         lastMod = self.lastModifiedDate or self.lastModified or "19700101";
       in rec {
         devShells.default = pkgs.mkShell { packages = with pkgs; [ nodejs ]; };
+
         packages.default = pkgs.buildNpmPackage rec {
           pname = "sweater-comb";
           version = builtins.substring 0 8 lastMod;
           src = ./.;
+
           npmDepsHash = "sha256-ljVq4otWSn7oRlUrSqzIXDKDDNGBrG1oMnz+Uf+pzeE=";
-          nativeBuildInputs = [ pkgs.nodePackages.node-gyp pkgs.python3 ];
           npmBuildScript = "build";
+
+          nativeBuildInputs = [ pkgs.nodePackages.node-gyp pkgs.python3 ];
+
+          postInstall = ''
+            mv $out/bin/@snyk/sweater-comb $out/bin
+            rmdir $out/bin/@snyk
+          '';
+
           meta = { 
-            mainProgram = "@snyk/sweater-comb"; 
             description = "OpenAPI linting rules for Snyk APIs";
             homepage = "https://github.com/snyk/sweater-comb";
             platforms = flake-utils.lib.defaultSystems;


### PR DESCRIPTION
This package builds @snyk/sweater-comb, which means the sweater-comb binary is not on the exported path from the resulting nix derivation. This is fine when running the result directly as it is picked up from mainProgram - however when consuming into a devShell it means that the binary is not in the users path.