### PR TITLE
fix: use node 18.18 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   resource_class: small
   docker:
-    - image: cimg/node:18.16.1
+    - image: cimg/node:18.18
   working_directory: ~/sweater-comb
 
 commands:


### PR DESCRIPTION
Semantic release dropped support for node 18.16.1, so we need to upgrade. This is the latest node 18 version as of commit time.