### PR TITLE
fix: allow multiple underscores in singular item params

### DIFF
--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/pagination-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/pagination-rules.test.ts
@@ -121,4 +121,31 @@ describe("pagination rules", () => {
     expect(results.every((result) => result.passed)).toBe(false);
     expect(results).toMatchSnapshot();
   });
+
+  test("skips when path is a singular item", async () => {
+    const afterJson = {
+      ...baseJson,
+      paths: {
+        "/api/users/{user_id}": {
+          get: {
+            responses: {},
+          },
+        },
+        // Ensure multiple underscores are supported
+        "/api/users/{foo_user_id}": {
+          get: {
+            responses: {},
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+
+    const ruleRunner = new RuleRunner([paginationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, afterJson),
+      context,
+    };
+    const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.length).toEqual(0);
+  });
 });

--- a/src/rulesets/rest/2022-05-25/utils.ts
+++ b/src/rulesets/rest/2022-05-25/utils.ts
@@ -12,7 +12,7 @@ export const isSingletonPath = (rulesContext: RuleContext) =>
   !!rulesContext.specification.raw.paths[rulesContext.operation.path]?.[
     "x-snyk-resource-singleton"
   ];
-export const isItemOperation = (path: string) => /\{[a-z]*?_?id\}$/.test(path);
+export const isItemOperation = (path: string) => /\{[a-z_]*?id\}$/.test(path);
 export const isBatchPostOperation = (requests) => {
   const request = requests.find(
     (request) => request.contentType === "application/vnd.api+json",


### PR DESCRIPTION
We were applying the pagination rules to items if the last parameter has more than one underscore, for example: scan_job_id. This is incorrect as they should be treated as single items, not collections.