### PR TITLE
fix: update base container image to fix high vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:18.17.1-bullseye-slim AS build-env
+FROM node:18.18.1-bullseye-slim AS build-env
 WORKDIR /sweater-comb
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:18.17.1-bullseye-slim AS clean-env
+FROM node:18.18.1-bullseye-slim AS clean-env
 COPY --from=build-env /sweater-comb/build/ /sweater-comb/
 COPY --from=build-env /sweater-comb/babel.config.js /sweater-comb/
 COPY --from=build-env /sweater-comb/package*.json /sweater-comb/
 WORKDIR /sweater-comb
 RUN npm install --production
 
-FROM node:18.17.1-bullseye-slim
+FROM node:18.18.1-bullseye-slim
 ENV NODE_ENV production
 COPY --from=clean-env /sweater-comb/ /sweater-comb/
 WORKDIR /sweater-comb


### PR DESCRIPTION
Some high vulns were found in the version of the base image we were using, fortunately a minor version bump fixes them. Sticking to LTS release of node.