### PR TITLE
fix: update base image to alpine

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+version: v1.25.0
+
+ignore:
+  SNYK-JS-AXIOS-6032459:
+    - '*':
+        reason: No upstream fix from OpticCI
+        expires: 2023-11-24T13:26:07.013Z
+        created: 2023-10-25T13:26:07.015Z
+patch: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:18.18.1-bullseye-slim AS build-env
+FROM node:18.18.2-alpine3.18 AS build-env
 WORKDIR /sweater-comb
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:18.18.1-bullseye-slim AS clean-env
+FROM node:18.18.2-alpine3.18 AS clean-env
 COPY --from=build-env /sweater-comb/build/ /sweater-comb/
 COPY --from=build-env /sweater-comb/babel.config.js /sweater-comb/
 COPY --from=build-env /sweater-comb/package*.json /sweater-comb/
 WORKDIR /sweater-comb
 RUN npm install --production
 
-FROM node:18.18.1-bullseye-slim
+FROM node:18.18.2-alpine3.18
 ENV NODE_ENV production
 COPY --from=clean-env /sweater-comb/ /sweater-comb/
 WORKDIR /sweater-comb


### PR DESCRIPTION
This change updates the base image to `node:18.18.2-alpine3.18` to remediate a critical vuln in zlib ([CVE-2023-45853](https://www.cve.org/CVERecord?id=CVE-2023-45853)) that was picked up by our SoS scanning.

