### PR TITLE
Fix: update node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   resource_class: small
   docker:
-    - image: cimg/node:18.18
+    - image: cimg/node:20.11
   working_directory: ~/sweater-comb
 
 commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:18.18.2-alpine3.18 AS build-env
+FROM node:20.11-alpine AS build-env
 WORKDIR /sweater-comb
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:18.18.2-alpine3.18 AS clean-env
+FROM node:20.11-alpine AS clean-env
 COPY --from=build-env /sweater-comb/build/ /sweater-comb/
 COPY --from=build-env /sweater-comb/babel.config.js /sweater-comb/
 COPY --from=build-env /sweater-comb/package*.json /sweater-comb/
 WORKDIR /sweater-comb
 RUN npm install --production
 
-FROM node:18.18.2-alpine3.18
+FROM node:20.11-alpine
 ENV NODE_ENV production
 COPY --from=clean-env /sweater-comb/ /sweater-comb/
 WORKDIR /sweater-comb

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694343207,
-        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
+        "lastModified": 1705883077,
+        "narHash": "sha256-ByzHHX3KxpU1+V0erFy8jpujTufimh6KaS/Iv3AciHk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "rev": "5f5210aa20e343b7e35f40c033000db0ef80d7b9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           version = builtins.substring 0 8 lastMod;
           src = ./.;
 
-          npmDepsHash = "sha256-ljVq4otWSn7oRlUrSqzIXDKDDNGBrG1oMnz+Uf+pzeE=";
+          npmDepsHash = "sha256-IMHX8KqW8kGdFxHgU0JcBwKByVw9U78pNDug12x63r0=";
           npmBuildScript = "build";
 
           nativeBuildInputs = [ pkgs.nodePackages.node-gyp pkgs.python3 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "typescript": "^4.4.4"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "/schemas"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "scripts": {
     "test": "jest --colors",

--- a/scripts/build-npm.bash
+++ b/scripts/build-npm.bash
@@ -11,5 +11,5 @@ npm pack
 export GITHUB_TOKEN=${GITHUB_TOKEN:-$GH_TOKEN}
 
 if [[ -n "$GITHUB_TOKEN" && -n "$NPM_TOKEN" ]]; then
-  npx semantic-release
+  npx "semantic-release@23"
 fi


### PR DESCRIPTION
semantic-release has dropped support for node 18, so unless we pin the
version we use or upgrade node, we cannot release. I'm choosing to do
both.

We cannot release new versions until this is fixed.