### PR TITLE
fix: prevent errors from optic being swallowed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,18 +77,14 @@ const main = async (): Promise<void> => {
   setRulesets(ruleset);
   setGenerateContext(readContextFrom);
 
-  cli.exitOverride().parse(process.argv);
+  await cli.exitOverride().parseAsync(process.argv);
 };
 
-process.exitCode = 1;
-main()
-  .then(() => {
+main().catch((err) => {
+  if (["commander.helpDisplayed", "commander.version"].includes(err.code)) {
     process.exitCode = 0;
-  })
-  .catch((err) => {
-    if (["commander.helpDisplayed", "commander.version"].includes(err.code)) {
-      process.exitCode = 0;
-      return;
-    }
-    console.log("exit on error:", err);
-  });
+    return;
+  }
+  process.exitCode = 1;
+  console.log("exit on error:", err);
+});


### PR DESCRIPTION
We are executing the optic commands async. This causes the main task to exit right away with a success state, but the process does not exit until all the async tasks are complete. This means that if an exception is thrown in an async task then we will not report that accurately in our process exit code.

Setting the exitCode to 1 then reverting it on success is the actual problem here. This program calls into its self multiple times for a run, which means if _any_ of those calls succeed then the whole task succeeds. This is not how it should work, we want the whole thing to fail if any child call fails.