### PR TITLE
feat: allow ulid type for resource ids

### DIFF
--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -8,6 +8,7 @@ In order to provide a consistent [API as a platform](../principles/api_program.m
 
 - `format: uuid`
 - `format: uri`
+- `format: ulid`
 
 UUIDs are most useful when the resource is already located by a unique UUID primary key.
 
@@ -15,6 +16,8 @@ URIs may be better when:
 
 - The resource identity is best located by a URI. For example: [Package URLs (pURLs)](https://github.com/package-url/purl-spec).
 - Other instances where a structured, semantically meaningful identifier provides a better experience. Vulnerabilities or issues might fall into this category.
+
+ULIDs (Universally Unique Lexicographically Sortable Identifiers) are advantageous for systems that require globally unique identifiers that are also sortable by time. They combine the benefits of UUIDs with the ability to order them chronologically.
 
 # Organization and group tenants for resources
 

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/__snapshots__/resource-object-rules.test.ts.snap
@@ -182,6 +182,189 @@ exports[`resource object rules valid DELETE responses passes when status code 20
 ]
 `;
 
+exports[`resource object rules valid GET responses passes when status code 200 has the correct JSON body identified by ulid 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API data property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "self links",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid get / post response data schema",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "description": "",
+        "statusCode": "200",
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1example/get/responses/200",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /api/example response 200",
+  },
+]
+`;
+
 exports[`resource object rules valid GET responses passes when status code 200 has the correct JSON body identified by uri 1`] = `
 [
   {
@@ -728,6 +911,235 @@ exports[`resource object rules valid PATCH responses passes when singleton statu
     "isMust": true,
     "isShould": false,
     "name": "valid patch singleton response data schema",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "description": "",
+        "statusCode": "200",
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "PATCH /api/example response 200",
+  },
+]
+`;
+
+exports[`resource object rules valid PATCH responses passes when status code 200 has the correct body identified by ulid 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#crud-updating-responses",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response data for patch",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API type property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "self links",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "PATCH /api/example response 200 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "200",
+          },
+          "method": "patch",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "patch",
+          "responses",
+          "200",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/patch/responses/200/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid patch response data schema",
     "passed": true,
     "received": undefined,
     "severity": 2,
@@ -1689,6 +2101,229 @@ exports[`resource object rules valid PATCH responses passes when status code 200
     "severity": 2,
     "type": "added",
     "where": "PATCH /api/example response 200",
+  },
+]
+`;
+
+exports[`resource object rules valid POST responses passes when status code 201 has the correct headers and body identified by ulid 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "include JSON:API data property for 2xx status codes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/example response 201 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "self links",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/example response 201 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "contentType": "application/vnd.api+json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/vnd.api+json",
+            },
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+          "application/vnd.api+json",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201/content/application~1vnd.api+json",
+        "kind": "body",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid get / post response data schema",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/example response 201 response body: application/vnd.api+json",
+  },
+  {
+    "change": {
+      "added": {
+        "description": "",
+        "statusCode": "201",
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "content for non-204 status codes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/example response 201",
+  },
+  {
+    "change": {
+      "added": {
+        "description": "",
+        "statusCode": "201",
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "201",
+          },
+          "method": "post",
+          "path": "/api/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/example",
+          "post",
+          "responses",
+          "201",
+        ],
+        "jsonPath": "/paths/~1api~1example/post/responses/201",
+        "kind": "response",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://jsonapi.org/format/#document-resource-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "location header",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /api/example response 201",
   },
 ]
 `;

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -66,7 +66,7 @@ describe("resource object rules", () => {
       expect(results.every((result) => result.passed)).toBe(true);
     });
 
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when PATCH request body is of the correct form identified by %s",
       async (format) => {
         const afterJson = {
@@ -122,7 +122,7 @@ describe("resource object rules", () => {
       },
     );
 
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when PATCH request body for a relationship is of the correct form (data is an collection of resource objects with id and type)",
       async (format) => {
         const afterJson = {
@@ -278,7 +278,7 @@ describe("resource object rules", () => {
       expect(results.every((result) => result.passed)).toBe(true);
     });
 
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when POST request body for a relationship is of the correct form (data is collection of resource objects with type and id)",
       async (format) => {
         const afterJson = {
@@ -705,7 +705,7 @@ describe("resource object rules", () => {
   });
 
   describe("valid GET responses", () => {
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when status code 200 has the correct JSON body identified by %s",
       async (format) => {
         const afterJson = {
@@ -765,7 +765,7 @@ describe("resource object rules", () => {
   });
 
   describe("valid POST responses", () => {
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when status code 201 has the correct headers and body identified by %s",
       async (format) => {
         const afterJson = {
@@ -833,7 +833,7 @@ describe("resource object rules", () => {
   });
 
   describe("valid PATCH responses", () => {
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when status code 200 has the correct body identified by %s",
       async (format) => {
         const afterJson = {
@@ -1046,7 +1046,7 @@ describe("resource object rules", () => {
       expect(results).toMatchSnapshot();
     });
 
-    test.each(["uuid", "uri"])(
+    test.each(["uuid", "uri", "ulid"])(
       "passes when DELETE request body for a relationship is of the correct form (data is collection of resource objects)",
       async (format) => {
         const afterJson = {

--- a/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
@@ -16,7 +16,7 @@ import {
 } from "../utils";
 
 const resourceIDFormat = new Matcher((value: any): boolean => {
-  return value === "uuid" || value === "uri";
+  return value === "uuid" || value === "uri" || value === "ulid";
 });
 
 const matchPatchRequest = {


### PR DESCRIPTION
This PR attempts to allow the ULID type for resource IDs.

ULIDs (Universally Unique Lexicographically Sortable Identifiers) are advantageous for systems that require globally unique identifiers that are also sortable by time. They combine the benefits of UUIDs with the ability to order them chronologically.
