### PR TITLE
Fix: Allow for one to one relationship requests

### DIFF
--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -129,7 +129,7 @@ describe("resource object rules", () => {
     );
 
     test.each(["uuid", "uri", "ulid"])(
-      "passes when PATCH request body for a relationship is of the correct form (data is an collection of resource objects with id and type)",
+      "passes when PATCH request body for a relationship is of the correct form (data is a single resource object with id and type)",
       async (format) => {
         const afterJson = {
           ...baseJson,
@@ -144,17 +144,14 @@ describe("resource object rules", () => {
                         type: "object",
                         properties: {
                           data: {
-                            type: "array",
-                            items: {
-                              type: "object",
-                              properties: {
-                                type: {
-                                  type: "string",
-                                },
-                                id: {
-                                  type: "string",
-                                  format: format,
-                                },
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              id: {
+                                type: "string",
+                                format: format,
                               },
                             },
                           },
@@ -227,7 +224,7 @@ describe("resource object rules", () => {
             where:
               "PATCH /api/example/relationships/example request body: application/vnd.api+json",
             name: "request body for relationship post/patch/delete",
-            error: "Expected a partial match",
+            error: "Expected at least one partial match",
           }),
         ]),
       );
@@ -335,6 +332,54 @@ describe("resource object rules", () => {
       },
     );
 
+    test.each(["uuid", "uri", "ulid"])(
+      "passes when POST request body for a relationship is of the correct form (data is a single resource object with type and id)",
+      async (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/relationships/example": {
+              post: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              id: {
+                                type: "string",
+                                format: format,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
+
     test("fails when POST request body for a relationship is of incorrect form (missing id from resource objects in data array)", async () => {
       const afterJson = {
         ...baseJson,
@@ -383,7 +428,7 @@ describe("resource object rules", () => {
             where:
               "POST /api/example/relationships/example request body: application/vnd.api+json",
             name: "request body for relationship post/patch/delete",
-            error: "Expected a partial match",
+            error: "Expected at least one partial match",
           }),
         ]),
       );
@@ -1168,6 +1213,54 @@ describe("resource object rules", () => {
       },
     );
 
+    test.each(["uuid", "uri", "ulid"])(
+      "passes when DELETE request body for a relationship is of the correct form (data is a resource object)",
+      async (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/relationships/example": {
+              delete: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "object",
+                            properties: {
+                              type: {
+                                type: "string",
+                              },
+                              id: {
+                                type: "string",
+                                format: format,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
+
     test("fails when DELETE request body for a relationship is of incorrect form (resource objects in collection missing id)", async () => {
       const afterJson = {
         ...baseJson,
@@ -1216,7 +1309,7 @@ describe("resource object rules", () => {
             where:
               "DELETE /api/example/relationships/example request body: application/vnd.api+json",
             name: "request body for relationship post/patch/delete",
-            error: "Expected a partial match",
+            error: "Expected at least one partial match",
           }),
         ]),
       );

--- a/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/__tests__/resource-object-rules.test.ts
@@ -129,6 +129,56 @@ describe("resource object rules", () => {
     );
 
     test.each(["uuid", "uri", "ulid"])(
+      "passes when PATCH request body for a relationship is of the correct form (data is an collection of resource objects with id and type)",
+      async (format) => {
+        const afterJson = {
+          ...baseJson,
+          paths: {
+            "/api/example/relationships/example": {
+              patch: {
+                responses: {}, // not tested here
+                requestBody: {
+                  content: {
+                    "application/vnd.api+json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                },
+                                id: {
+                                  type: "string",
+                                  format: format,
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenAPIV3.Document;
+        const ruleRunner = new RuleRunner([resourceObjectRules]);
+        const ruleInputs = {
+          ...TestHelpers.createRuleInputs(baseJson, afterJson),
+          context,
+        };
+        const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.passed)).toBe(true);
+      },
+    );
+
+    test.each(["uuid", "uri", "ulid"])(
       "passes when PATCH request body for a relationship is of the correct form (data is a single resource object with id and type)",
       async (format) => {
         const afterJson = {

--- a/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
@@ -121,7 +121,7 @@ const requestDataForPost = new RequestRule({
   },
 });
 
-// Relationship POST, PATCH, and DELETE requests must have
+// Relationship POST, PATCH, and DELETE requests can have
 // a request body with resource objects for the relationships
 // to be added/patched/deleted.
 const matchRelationshipModificationRequestArrayData = {
@@ -142,9 +142,9 @@ const matchRelationshipModificationRequestArrayData = {
   },
 };
 
-// Relationship POST, PATCH, and DELETE requests must have
-// a request body with resource objects for the relationships
-// to be added/patched/deleted.
+// Relationship POST, PATCH, and DELETE requests can have
+// a request body with a resource object for the single relationship
+// to be added (set)/patched/deleted.
 const matchRelationshipModificationRequestSingleData = {
   data: {
     type: "object",

--- a/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
+++ b/src/rulesets/rest/2022-05-25/json-api-rules/resource-object-rules.ts
@@ -124,7 +124,7 @@ const requestDataForPost = new RequestRule({
 // Relationship POST, PATCH, and DELETE requests must have
 // a request body with resource objects for the relationships
 // to be added/patched/deleted.
-const matchRelationshipModificationRequestData = {
+const matchRelationshipModificationRequestArrayData = {
   data: {
     type: "array",
     items: {
@@ -142,6 +142,24 @@ const matchRelationshipModificationRequestData = {
   },
 };
 
+// Relationship POST, PATCH, and DELETE requests must have
+// a request body with resource objects for the relationships
+// to be added/patched/deleted.
+const matchRelationshipModificationRequestSingleData = {
+  data: {
+    type: "object",
+    properties: {
+      type: {
+        type: Matchers.string,
+      },
+      id: {
+        type: "string",
+        format: resourceIDFormat,
+      },
+    },
+  },
+};
+
 const requestDataForRelationshipModification = new RequestRule({
   name: "request body for relationship post/patch/delete",
   docsLink: links.jsonApi.postRequests,
@@ -150,18 +168,34 @@ const requestDataForRelationshipModification = new RequestRule({
     request.contentType === "application/vnd.api+json" &&
     ["patch", "delete", "post"].includes(rulesContext.operation.method),
   rule: (requestAssertions) => {
-    requestAssertions.body.added.matches({
-      schema: {
-        type: "object",
-        properties: matchRelationshipModificationRequestData,
+    requestAssertions.body.added.matchesOneOf([
+      {
+        schema: {
+          type: "object",
+          properties: matchRelationshipModificationRequestArrayData,
+        },
       },
-    });
-    requestAssertions.body.changed.matches({
-      schema: {
-        type: "object",
-        properties: matchRelationshipModificationRequestData,
+      {
+        schema: {
+          type: "object",
+          properties: matchRelationshipModificationRequestSingleData,
+        },
       },
-    });
+    ]);
+    requestAssertions.body.changed.matchesOneOf([
+      {
+        schema: {
+          type: "object",
+          properties: matchRelationshipModificationRequestArrayData,
+        },
+      },
+      {
+        schema: {
+          type: "object",
+          properties: matchRelationshipModificationRequestSingleData,
+        },
+      },
+    ]);
   },
 });
 


### PR DESCRIPTION
As discussed in https://snyk.slack.com/archives/C040Q5G1Q3G/p1725293953086929 , it was detected that all relationship updates are to-many requests, but a relationship request with just an entity should be allowed as well.

This change adds support for that, so that both bodies are allowed in a relationship update (post / patch / delete) request:
* this (as previously):
```
  data: {
    type: "array",
    items: {
      type: "object",
      properties: {
        type: {
          type: Matchers.string,
        },
        id: {
          type: "string",
          format: resourceIDFormat,
        },
      },
    },
  }
``` 
* but also this (single entity):
```
  data: {
    type: "object",
    properties: {
      type: {
        type: Matchers.string,
      },
      id: {
        type: "string",
        format: resourceIDFormat,
      },
    },
  }
```
Tests have been modified as the error message changed, and also positive tests for the single entity cases have been added.