### PR TITLE
feat: add rule to prevent mapping objects in discriminators

### DIFF
--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -711,6 +711,19 @@ Without examples, as an end-user I don't have much context here to know what the
 - If fields, objects, and/or relationships are not supplied in the request they are not modified.
 - To unset an existing attribute supply a value of `null`.
 
+
+## Polymorphic Objects
+
+While OpenAPI provides mechanisms for alternative schemas with the `oneOf` and
+`anyOf` keywords, their use is discouraged. Typically the reach for one of
+these indicates the endpoint is overloaded and as such would be better modeled
+as several more atomic endpoints.
+
+We do not prevent the use of these constructs, however due to a bug in our
+tooling we cannot handle mapping objects in discriminators. As such the use of
+these is currently prevented with a linting rule.
+
+
 ## Making the OpenAPI specification available
 
 Every service in the REST API must publish endpoints that list available versions and fetch specific published versions of the OpenAPI spec for all resources provided by that service to REST. These paths may be prefixed if needed (some services may provide other APIs in addition to REST).

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705883077,
-        "narHash": "sha256-ByzHHX3KxpU1+V0erFy8jpujTufimh6KaS/Iv3AciHk=",
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f5210aa20e343b7e35f40c033000db0ef80d7b9",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
         "type": "github"
       },
       "original": {

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -35,6 +35,8 @@ export const links = {
       "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#parameter-names-and-path-components",
     timestampProperties:
       "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#timestamp-properties",
+    polymorphicObjects:
+      "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
   },
   jsonApi: {
     contentType: "https://jsonapi.org/format/#content-negotiation-clients",

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/specification-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/specification-rules.test.ts.snap
@@ -250,6 +250,114 @@ exports[`specification rules compiled specs fails when /openapi/{versions} endpo
 ]
 `;
 
+exports[`specification rules fails if a discriminator is added with a mapping object 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": {
+        "info": {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.0",
+        "x-snyk-api-stability": "wip",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#referenced-entities",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "component names",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "specification",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": {
+        "info": {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.0",
+        "x-snyk-api-stability": "wip",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#tags",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "open api version names",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "specification",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+          "x-snyk-api-stability": "wip",
+        },
+        "before": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+        },
+      },
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
+    "error": "Mapping object is not permitted in discriminators",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no mapping objects in discriminators",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "specification",
+  },
+]
+`;
+
 exports[`specification rules fails when components are not PascalCase 1`] = `
 [
   {
@@ -312,6 +420,47 @@ exports[`specification rules fails when components are not PascalCase 1`] = `
     "received": undefined,
     "severity": 2,
     "type": "requirement",
+    "where": "specification",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+          "x-snyk-api-stability": "wip",
+        },
+        "before": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+        },
+      },
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no mapping objects in discriminators",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
     "where": "specification",
   },
 ]
@@ -381,6 +530,47 @@ exports[`specification rules uncompiled specs passes when /openapi endpoint isn'
     "type": "requirement",
     "where": "specification",
   },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+          "x-snyk-api-stability": "wip",
+        },
+        "before": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+        },
+      },
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no mapping objects in discriminators",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "specification",
+  },
 ]
 `;
 
@@ -446,6 +636,47 @@ exports[`specification rules uncompiled specs passes when /openapi/{versions} en
     "received": undefined,
     "severity": 2,
     "type": "requirement",
+    "where": "specification",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+          "x-snyk-api-stability": "wip",
+        },
+        "before": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+        },
+      },
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no mapping objects in discriminators",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
     "where": "specification",
   },
 ]

--- a/src/rulesets/rest/2022-05-25/__tests__/specification-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/specification-rules.test.ts
@@ -45,6 +45,45 @@ describe("specification rules", () => {
     expect(results).toMatchSnapshot();
   });
 
+  test("fails if a discriminator is added with a mapping object", async () => {
+    const afterJson = {
+      ...baseJson,
+      [stabilityKey]: "wip",
+      paths: {},
+      components: {
+        parameters: {
+          OrgId: {
+            name: "orgId",
+            in: "path",
+          },
+          ThingId: {
+            name: "thingId",
+            in: "path",
+          },
+        },
+        schemas: {
+          OneOfSchema: {
+            type: "object",
+            description: "Response containing a single thing resource object",
+            oneOf: [],
+            discriminator: {
+              propertyName: "foo",
+              mapping: {},
+            },
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+    const ruleRunner = new RuleRunner([specificationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, afterJson),
+      context,
+    };
+    const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+    expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+
   describe("compiled specs", () => {
     test("fails when /openapi endpoint isn't specified", async () => {
       const afterJson: OpenAPIV3.Document = {


### PR DESCRIPTION
The mapping objects type is a record of string to string, however the values
are considered references. Since the values are not deserialised as refs by
vervet, the reference objects are not copied when compiling the specs which
lead to invalid specs. This is an issue with the upstream library and is hard
to fix on our side.

The use of discriminator mapping objects should be discouraged. This patch adds
documentations to assert that as well as a linting rule to prevent mapping
objects entirely to avoid the above bug. If we fix the bug this rule may be
removed again but the docs should stay.