### PR TITLE
docs: added excludes to the docs

### DIFF
--- a/docs/sweater-comb/index.md
+++ b/docs/sweater-comb/index.md
@@ -1,7 +1,25 @@
 # About this project
 
-COMING SOON:
+## How to use
 
+Sweater Comb should work out of the box when using the sample service templates.
+
+### Removing endpoints
+The service templates contain example endpoints. Removing them will result in a linting error due to the breaking change.
+It is possible to exclude these endpoints from both linting & spec generation by using the `excludes` property e.g..
+```yaml
+apis:
+  internal:
+    resources:
+      - path: "internal/api/intl/resources"
+        linter: api-resource
+        excludes:
+          - "**/internal/api/intl/resources/repos/2022-04-04/spec.yaml"
+```
+
+
+
+COMING SOON:
 - How to contribute (link to or supplement CONTRIBUTING)
   - Amending the standards, proposing changes, etc.
   - Making standards executable -- writing Optic CI rules


### PR DESCRIPTION
## What it does
Small PR to add documentation around how to disable linting when trying to remove endpoints - e.g. when using the service template