### PR TITLE
feat: allow namespaced component names

### DIFF
--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -105,11 +105,38 @@ Resource collection names, parameters and path variables must use **snake case**
 
 Because these variables are represented in URLs, uppercase letters may cause problems on some client platforms; RFCs recommend that URLs are treated as case-sensitive, but it is a "should", not a "must". Dashes might cause problems for some code generators, ruling out kebab case.
 
-### Referenced Entities
+### Component naming
 
-Entities referenced in other documents (using `$ref`) must use **pascal case** names.
+[OpenAPI components](https://spec.openapis.org/oas/v3.1.0#components-object) must use **pascal case** names.
 
-Entities will be commonly represented as types or classes when generating code. Pascal case names are conventionally used for such symbols in most targeted languages.
+When generating OpenAPI with [TypeSpec](https://typespec.io/)'s [OpenAPI emitter](https://typespec.io/docs/emitters/openapi3/reference/emitter/),
+these names may be prefixed by a dot-separated lower-case namespace. Components derived from a model property may be suffixed by a snake-cased property name.
+
+To illustrate,
+
+```typespec
+namespace io.snyk.api.common;
+
+model SnykApiRequest {
+  @header("snyk-request-id")
+  @format("uuid")
+  request_id?: string;
+}
+```
+
+might produce an OpenAPI component:
+
+```yaml
+components:
+  parameters:
+    "io.snyk.api.common.SnykApiRequest.request_id":
+      name: snyk-request-id
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid
+```
 
 ### Schema properties
 

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/specification-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/specification-rules.test.ts.snap
@@ -379,13 +379,121 @@ exports[`specification rules fails when components are not PascalCase 1`] = `
     },
     "condition": undefined,
     "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#referenced-entities",
-    "error": "Expected thingResourceResponse to be pascal case",
+    "error": "Expected notSnakey to be pascal case in component io.snyk.something.ThingResourceResponse.notSnakey",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
     "isShould": false,
     "name": "component names",
     "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "specification",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": {
+        "info": {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.0",
+        "x-snyk-api-stability": "wip",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#tags",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "open api version names",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "specification",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+          "x-snyk-api-stability": "wip",
+        },
+        "before": {
+          "info": {
+            "title": "Empty",
+            "version": "0.0.0",
+          },
+          "openapi": "3.1.0",
+        },
+      },
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "no mapping objects in discriminators",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "specification",
+  },
+]
+`;
+
+exports[`specification rules passes when components are namespaced PascalCase 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {},
+        "conceptualPath": [],
+        "jsonPath": "",
+        "kind": "specification",
+      },
+      "value": {
+        "info": {
+          "title": "Empty",
+          "version": "0.0.0",
+        },
+        "openapi": "3.1.0",
+        "x-snyk-api-stability": "wip",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#referenced-entities",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "component names",
+    "passed": true,
     "received": undefined,
     "severity": 2,
     "type": "requirement",

--- a/src/rulesets/rest/2022-05-25/__tests__/specification-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/specification-rules.test.ts
@@ -23,9 +23,18 @@ describe("specification rules", () => {
             name: "thingId",
             in: "path",
           },
+          "io.snyk.something.ThingResourceResponse.notSnakey": {
+            name: "not-snakey",
+            in: "header",
+          },
         },
         schemas: {
           thingResourceResponse: {
+            type: "object",
+            description: "Response containing a single thing resource object",
+            properties: {},
+          },
+          "IO.SNYK.SOMETHING.ThingResourceResponse": {
             type: "object",
             description: "Response containing a single thing resource object",
             properties: {},
@@ -42,6 +51,44 @@ describe("specification rules", () => {
 
     expect(results.length).toBeGreaterThan(0);
     expect(results.every((result) => result.passed)).toBe(false);
+    expect(results).toMatchSnapshot();
+  });
+
+  test("passes when components are namespaced PascalCase", async () => {
+    const afterJson = {
+      ...baseJson,
+      [stabilityKey]: "wip",
+      paths: {},
+      components: {
+        schemas: {
+          "something.ThingResourceResponse": {
+            type: "object",
+            description: "Response containing a single thing resource object",
+            properties: {},
+          },
+          "io.snyk.something.ThingResourceResponse": {
+            type: "object",
+            description: "Response containing a single thing resource object",
+            properties: {},
+          },
+        },
+        parameters: {
+          "io.snyk.something.SomeApiRequest.some_param": {
+            in: "path",
+            name: "some_param",
+          },
+        },
+      },
+    } as OpenAPIV3.Document;
+    const ruleRunner = new RuleRunner([specificationRules]);
+    const ruleInputs = {
+      ...TestHelpers.createRuleInputs(baseJson, afterJson),
+      context,
+    };
+    const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.passed)).toBe(true);
     expect(results).toMatchSnapshot();
   });
 


### PR DESCRIPTION
OpenAPI generated by Typespec will use namespace-qualified component names in the generated OpenAPI, when types are in a different namespace from that of the OpenAPI spec.

This updates the componentNameCase rule to allow PascalCase component names with a dot.case namespace prefix.

~~DONE: figure out how to deal with TypeSpec materialized component names for parameters.~~