### PR TITLE
fix: remove mapping restriction on polymorphic oneof types

### DIFF
--- a/docs/standards/rest.md
+++ b/docs/standards/rest.md
@@ -741,15 +741,14 @@ Without examples, as an end-user I don't have much context here to know what the
 
 ## Polymorphic Objects
 
-While OpenAPI provides mechanisms for alternative schemas with the `oneOf` and
-`anyOf` keywords, their use is discouraged. Typically the reach for one of
-these indicates the endpoint is overloaded and as such would be better modeled
-as several more atomic endpoints.
+OpenAPI can express polymorphism with composite types, using the `oneOf` or
+`anyOf` keywords.
 
-We do not prevent the use of these constructs, however due to a bug in our
-tooling we cannot handle mapping objects in discriminators. As such the use of
-these is currently prevented with a linting rule.
+`oneOf` should be preferred, and used with a `discriminator` property to express
+polymorphic type unions.
 
+Such polymorphic types are supported by OpenAPI code generation tools such as
+[oapi-codegen](https://github.com/oapi-codegen/oapi-codegen).
 
 ## Making the OpenAPI specification available
 

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/specification-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/specification-rules.test.ts.snap
@@ -422,47 +422,6 @@ exports[`specification rules fails when components are not PascalCase 1`] = `
     "type": "requirement",
     "where": "specification",
   },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-          "x-snyk-api-stability": "wip",
-        },
-        "before": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-        },
-      },
-      "location": {
-        "conceptualLocation": {},
-        "conceptualPath": [],
-        "jsonPath": "",
-        "kind": "specification",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "no mapping objects in discriminators",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "specification",
-  },
 ]
 `;
 
@@ -528,47 +487,6 @@ exports[`specification rules passes when components are namespaced PascalCase 1`
     "received": undefined,
     "severity": 2,
     "type": "requirement",
-    "where": "specification",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-          "x-snyk-api-stability": "wip",
-        },
-        "before": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-        },
-      },
-      "location": {
-        "conceptualLocation": {},
-        "conceptualPath": [],
-        "jsonPath": "",
-        "kind": "specification",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "no mapping objects in discriminators",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
     "where": "specification",
   },
 ]
@@ -638,47 +556,6 @@ exports[`specification rules uncompiled specs passes when /openapi endpoint isn'
     "type": "requirement",
     "where": "specification",
   },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-          "x-snyk-api-stability": "wip",
-        },
-        "before": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-        },
-      },
-      "location": {
-        "conceptualLocation": {},
-        "conceptualPath": [],
-        "jsonPath": "",
-        "kind": "specification",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "no mapping objects in discriminators",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "specification",
-  },
 ]
 `;
 
@@ -744,47 +621,6 @@ exports[`specification rules uncompiled specs passes when /openapi/{versions} en
     "received": undefined,
     "severity": 2,
     "type": "requirement",
-    "where": "specification",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-          "x-snyk-api-stability": "wip",
-        },
-        "before": {
-          "info": {
-            "title": "Empty",
-            "version": "0.0.0",
-          },
-          "openapi": "3.1.0",
-        },
-      },
-      "location": {
-        "conceptualLocation": {},
-        "conceptualPath": [],
-        "jsonPath": "",
-        "kind": "specification",
-      },
-    },
-    "condition": undefined,
-    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#polymorphic-objects",
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "no mapping objects in discriminators",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
     "where": "specification",
   },
 ]

--- a/src/rulesets/rest/2022-05-25/__tests__/specification-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/specification-rules.test.ts
@@ -92,45 +92,6 @@ describe("specification rules", () => {
     expect(results).toMatchSnapshot();
   });
 
-  test("fails if a discriminator is added with a mapping object", async () => {
-    const afterJson = {
-      ...baseJson,
-      [stabilityKey]: "wip",
-      paths: {},
-      components: {
-        parameters: {
-          OrgId: {
-            name: "orgId",
-            in: "path",
-          },
-          ThingId: {
-            name: "thingId",
-            in: "path",
-          },
-        },
-        schemas: {
-          OneOfSchema: {
-            type: "object",
-            description: "Response containing a single thing resource object",
-            oneOf: [],
-            discriminator: {
-              propertyName: "foo",
-              mapping: {},
-            },
-          },
-        },
-      },
-    } as OpenAPIV3.Document;
-    const ruleRunner = new RuleRunner([specificationRules]);
-    const ruleInputs = {
-      ...TestHelpers.createRuleInputs(baseJson, afterJson),
-      context,
-    };
-    const results = await ruleRunner.runRulesWithFacts(ruleInputs);
-    expect(results.every((result) => result.passed)).toBe(false);
-    expect(results).toMatchSnapshot();
-  });
-
   describe("compiled specs", () => {
     test("fails when /openapi endpoint isn't specified", async () => {
       const afterJson: OpenAPIV3.Document = {

--- a/src/rulesets/rest/2022-05-25/specification-rules.ts
+++ b/src/rulesets/rest/2022-05-25/specification-rules.ts
@@ -148,55 +148,7 @@ const tags = new SpecificationRule({
   },
 });
 
-const noDiscriminatorMapping = new SpecificationRule({
-  name: "no mapping objects in discriminators",
-  docsLink: links.standards.polymorphicObjects,
-  rule: (specificationAssertions) => {
-    specificationAssertions.addedOrChanged(
-      "no mapping objects in discriminators",
-      (specification) => {
-        // propertyName is the only required field on a discriminator object,
-        // plus we only care about the objects with mappings
-        const discriminators = findObjectsWithFields([
-          "propertyName",
-          "mapping",
-        ])(specification.raw);
-
-        if (discriminators.length != 0) {
-          throw new RuleError({
-            message: "Mapping object is not permitted in discriminators",
-          });
-        }
-      },
-    );
-  },
-});
-
-const findObjectsWithFields = (fields: string[]) => (from: unknown) => {
-  if (typeof from !== "object" || from == null) {
-    return [];
-  }
-  return Object.values(from).flatMap((v) => {
-    if (typeof v !== "object" || v == null) {
-      return [];
-    }
-    if (Array.isArray(v)) {
-      return v.flatMap(findObjectsWithFields(fields));
-    }
-    if (fields.every((field) => field in v)) {
-      return [v];
-    }
-    return findObjectsWithFields(fields)(v);
-  });
-};
-
 export const specificationRules = new Ruleset({
   name: "specification rules",
-  rules: [
-    componentNameCase,
-    tags,
-    getOpenApiVersions,
-    listOpenApiVersions,
-    noDiscriminatorMapping,
-  ],
+  rules: [componentNameCase, tags, getOpenApiVersions, listOpenApiVersions],
 });


### PR DESCRIPTION
This removes the rule that fails on a defined discriminator mapping.

There isn't a good reason to prevent the use of the mapping keyword in Snyk's OpenAPI specifications.

I think this restriction was placed years ago, when Snyk was developing custom code generators, and these couldn't handle the complexity. These haven't been well-maintained at Snyk though, and the open source code generators we're now using, such as oapi-codegen, seem to handle these quite well.

The language discouraging the use of discriminators also hasn't aged well. There are valid reasons and numerous use cases for union type variants in resource attributes.

The Common Issue Model, assets, and findings all benefit from some conditionally-specific variant attributes.