### PR TITLE
chore: EXT-2825 upgrade jsonpath to fix critical vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5393,15 +5393,6 @@
         "openid-client": "^5.3.0"
       }
     },
-    "node_modules/@kubernetes/client-node/node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -17337,10 +17328,9 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
-      "license": "MIT",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "dependencies": {
         "@jsep-plugin/assignment": "^1.3.0",
         "@jsep-plugin/regex": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "yargs": "~17.6.0"
   },
   "overrides": {
-    "postman-collection": "4.2.0"
+    "postman-collection": "4.2.0",
+    "jsonpath-plus": "^10.3.0"
   },
   "jest": {
     "maxWorkers": 5,


### PR DESCRIPTION
We have a Critical sev in sweater-comb:
<img width="1204" alt="Screenshot 2025-02-18 at 10 49 12" src="https://github.com/user-attachments/assets/63023409-1c3d-4198-8700-535a08b2e78f" />

Because of this, other projects are affected.

In order to fix it, we need to upgrade **jsonpath-plus** to **10.3.0**
