### PR TITLE
feat: ext-2655 add ruleset for enum

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,8 @@ bcb88b2efeb56fabf49ccf4223d26cee3ec740e5:docs/standards/rest.md:generic-api-key:
 2b0351e5da078cf03863cb925e4493cd8d6da2e9:src/rulesets-new/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:1508
 8a2b8ab2e093291735418a8e8bee856dc8ce537c:src/rulesets/tests/__snapshots__/properties.test.ts.snap:generic-api-key:1077
 8a2b8ab2e093291735418a8e8bee856dc8ce537c:src/rulesets/tests/__snapshots__/properties.test.ts.snap:generic-api-key:1171
+02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:6875
+02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:6926
+02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:7003
+02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:7027
+

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,8 +6,9 @@ bcb88b2efeb56fabf49ccf4223d26cee3ec740e5:docs/standards/rest.md:generic-api-key:
 2b0351e5da078cf03863cb925e4493cd8d6da2e9:src/rulesets-new/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:1508
 8a2b8ab2e093291735418a8e8bee856dc8ce537c:src/rulesets/tests/__snapshots__/properties.test.ts.snap:generic-api-key:1077
 8a2b8ab2e093291735418a8e8bee856dc8ce537c:src/rulesets/tests/__snapshots__/properties.test.ts.snap:generic-api-key:1171
-02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:6875
-02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:6926
-02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:7003
-02916330e08247afcb2ac40b69e0bb50351b1c0d:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:7027
+f72fb19cf994004182867132e228e0e6c4a5e8cb:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:6875
+f72fb19cf994004182867132e228e0e6c4a5e8cb:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:6926
+f72fb19cf994004182867132e228e0e6c4a5e8cb:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:7003
+f72fb19cf994004182867132e228e0e6c4a5e8cb:src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap:generic-api-key:7027
+
 

--- a/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap
+++ b/src/rulesets/rest/2022-05-25/__tests__/__snapshots__/property-rules.test.ts.snap
@@ -764,6 +764,4731 @@ exports[`body properties breaking changes passes if a required property is added
 
 exports[`body properties breaking changes passes if spec is removed 1`] = `[]`;
 
+exports[`body properties enum value changes fails if an enum value is changed in a request property 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValC",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Cannot remove or change enum value 'ValA' from request property 'test_enum_prop'. This is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes fails if an enum value is changed in a response property 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValC",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Cannot remove or change enum value 'ValA' from response property 'test_enum_prop'. This is a breaking change.",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValC",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes fails if an enum value is removed from a request property 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Cannot remove or change enum value 'ValA' from request property 'test_enum_prop'. This is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes fails if an enum value is removed from a response property 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Cannot remove or change enum value 'ValA' from response property 'test_enum_prop'. This is a breaking change.",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes passes if a non-enum property is changed 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "default": "abc",
+          "type": "string",
+        },
+        "key": "test_string_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "default": "abc",
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_string_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_string_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_string_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_string_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_string_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes passes if an enum value is added to a request property 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes passes if an enum value is added to a response property 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+            ],
+            "type": "string",
+          },
+          "key": "test_enum_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_enum_prop",
+  },
+]
+`;
+
+exports[`body properties enum value changes passes if enum values are not changed 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_enum_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_enum_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_enum_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_enum_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_enum_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+]
+`;
+
 exports[`body properties key allows non-snake case if already in spec 1`] = `
 [
   {
@@ -2849,6 +7574,7085 @@ exports[`body properties key passes when snake case with one component 1`] = `
     "severity": 2,
     "type": "added",
     "where": "GET /example response 200 response body: application/json property technicallysnakecase",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a request property changes from boolean to boolean+enum 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            true,
+          ],
+          "type": "boolean",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              true,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: boolean) is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a request property changes from integer to integer+enum 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            1,
+            2,
+          ],
+          "type": "integer",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: integer) is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a request property changes from number to number+enum 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            1.1,
+            2.2,
+          ],
+          "type": "number",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: number) is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a request property changes from string to string+enum 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: string) is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a response property changes from boolean to boolean+enum 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            false,
+          ],
+          "type": "boolean",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              false,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              false,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              false,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              false,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              false,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              false,
+            ],
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "boolean",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: boolean) is a breaking change.",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a response property changes from integer to integer+enum 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            1,
+            2,
+          ],
+          "type": "integer",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: integer) is a breaking change.",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a response property changes from number to number+enum 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            1.1,
+            2.2,
+          ],
+          "type": "number",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1.1,
+              2.2,
+            ],
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "number",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: number) is a breaking change.",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes fails if a response property changes from string to string+enum 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing format in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing pattern in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response enum value removal",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": "Changing property 'test_prop' from a type without an enum to a type with an enum (new type: string) is a breaking change.",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property type to enum",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if integer to integer+enum in request is experimental 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            1,
+            2,
+          ],
+          "type": "integer",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              1,
+              2,
+            ],
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "integer",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if request property added as string+enum 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property casing",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/principles/version.md#breaking-changes",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent adding a required request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#formats",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property enum or example",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#timestamp-properties",
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request property date formatting",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if request property string to string (no enum) 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if response property added as string+enum 1`] = `
+[
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property casing",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": "https://github.com/snyk/sweater-comb/blob/main/docs/standards/rest.md#formats",
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response property date formatting",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "added": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "added",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if response property string to string (no enum) 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if string to string+enum in request is experimental 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in request property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "POST /example request body: application/json property: data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1example/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request schema properties",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /example request body: application/json",
+  },
+]
+`;
+
+exports[`body properties string to enum changes passes if string to string+enum in response is experimental 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "data",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "object",
+        },
+        "key": "attributes",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "enum": [
+            "ValA",
+            "ValB",
+          ],
+          "type": "string",
+        },
+        "key": "test_prop",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response array with items",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "ValA",
+              "ValB",
+            ],
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "type": "string",
+          },
+          "key": "test_prop",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "data",
+            "attributes",
+            "test_prop",
+          ],
+          "method": "get",
+          "path": "/example",
+        },
+        "conceptualPath": [
+          "operations",
+          "/example",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "data",
+          "attributes",
+          "test_prop",
+        ],
+        "jsonPath": "/paths/~1example/get/responses/200/content/application~1json/schema/properties/data/properties/attributes/properties/test_prop",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "valid collection type in response property",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /example response 200 response body: application/json property data/attributes/test_prop",
   },
   {
     "change": {

--- a/src/rulesets/rest/2022-05-25/__tests__/property-rules.test.ts
+++ b/src/rulesets/rest/2022-05-25/__tests__/property-rules.test.ts
@@ -1470,6 +1470,1115 @@ describe("body properties", () => {
     });
   });
 
+  describe("enum value changes", () => {
+    const requestBodyWithEnum = (
+      enumVals: string[],
+    ): OpenAPIV3.OperationObject => ({
+      requestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                data: {
+                  type: "object",
+                  properties: {
+                    attributes: {
+                      type: "object",
+                      properties: {
+                        test_enum_prop: {
+                          type: "string",
+                          enum: enumVals,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {}, // Default responses object for an operation
+    });
+
+    const responseBodyWithEnum = (
+      enumVals: string[],
+    ): OpenAPIV3.OperationObject => ({
+      responses: {
+        "200": {
+          description: "",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  data: {
+                    type: "object",
+                    properties: {
+                      attributes: {
+                        type: "object",
+                        properties: {
+                          test_enum_prop: {
+                            type: "string",
+                            enum: enumVals,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    test("fails if an enum value is removed from a request property", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValA", "ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "request enum value removal",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if an enum value is removed from a response property", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithEnum(["ValA", "ValB"]),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithEnum(["ValB"]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "response enum value removal",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if an enum value is changed in a request property", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValA", "ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValC", "ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "request enum value removal",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if an enum value is changed in a response property", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithEnum(["ValA", "ValB"]),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithEnum(["ValC", "ValB"]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "response enum value removal",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if an enum value is added to a request property", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValA"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValA", "ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const enumRemovalResults = results.filter(
+        (r) =>
+          r.name === "request enum value removal" ||
+          r.name === "response enum value removal",
+      );
+      expect(enumRemovalResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if an enum value is added to a response property", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithEnum(["ValA"]),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithEnum(["ValA", "ValB"]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const enumRemovalResults = results.filter(
+        (r) =>
+          r.name === "request enum value removal" ||
+          r.name === "response enum value removal",
+      );
+      expect(enumRemovalResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if enum values are not changed", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValA", "ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithEnum(["ValA", "ValB"]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const enumRemovalResults = results.filter(
+        (r) =>
+          r.name === "request enum value removal" ||
+          r.name === "response enum value removal",
+      );
+      expect(enumRemovalResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if a non-enum property is changed", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            attributes: {
+                              type: "object",
+                              properties: {
+                                test_string_prop: { type: "string" },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            attributes: {
+                              type: "object",
+                              properties: {
+                                test_string_prop: {
+                                  type: "string",
+                                  default: "abc",
+                                }, // changed by adding default
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const enumRemovalResults = results.filter(
+        (r) =>
+          r.name === "request enum value removal" ||
+          r.name === "response enum value removal",
+      );
+      expect(enumRemovalResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("string to enum changes", () => {
+    const requestBodyWithPropertyTypeAndOptionalEnum = (
+      propertyType: OpenAPIV3.SchemaObject["type"],
+      enumVals?: string[] | number[] | boolean[],
+    ): OpenAPIV3.OperationObject => {
+      const propertySchema: OpenAPIV3.SchemaObject = {
+        type: propertyType as OpenAPIV3.NonArraySchemaObjectType,
+      };
+      if (enumVals) {
+        propertySchema.enum = enumVals;
+      }
+      return {
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  data: {
+                    type: "object",
+                    properties: {
+                      attributes: {
+                        type: "object",
+                        properties: {
+                          test_prop: propertySchema,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {},
+      };
+    };
+
+    const responseBodyWithPropertyTypeAndOptionalEnum = (
+      propertyType: OpenAPIV3.SchemaObject["type"],
+      enumVals?: string[] | number[] | boolean[],
+    ): OpenAPIV3.OperationObject => {
+      const propertySchema: OpenAPIV3.SchemaObject = {
+        type: propertyType as OpenAPIV3.NonArraySchemaObjectType,
+      };
+      if (enumVals) {
+        propertySchema.enum = enumVals;
+      }
+      return {
+        responses: {
+          "200": {
+            description: "",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "object",
+                      properties: {
+                        attributes: {
+                          type: "object",
+                          properties: {
+                            test_prop: propertySchema,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+    };
+
+    test("fails if a request property changes from string to string+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string"), // No enum initially
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string", [
+                "ValA",
+                "ValB",
+              ]), // Enum added
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "request property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if a response property changes from string to string+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string"), // No enum initially
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string", [
+                "ValA",
+                "ValB",
+              ]), // Enum added
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every((result) => result.passed)).toBe(false);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "response property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if string to string+enum in request is experimental", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string", [
+                "ValA",
+                "ValB",
+              ]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context: {
+          ...context,
+          changeVersion: {
+            date: "2021-10-10",
+            stability: "experimental",
+          },
+        },
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const targetRuleResults = results.filter(
+        (r) => r.name === "request property type to enum",
+      );
+      expect(targetRuleResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if string to string+enum in response is experimental", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string"),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string", [
+                "ValA",
+                "ValB",
+              ]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context: {
+          ...context,
+          changeVersion: {
+            date: "2021-10-10",
+            stability: "experimental",
+          },
+        },
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const targetRuleResults = results.filter(
+        (r) => r.name === "response property type to enum",
+      );
+      expect(targetRuleResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if request property added as string+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          properties: {
+                            attributes: { type: "object", properties: {} },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string", [
+                "ValA",
+                "ValB",
+              ]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const targetRuleResults = results.filter(
+        (r) => r.name === "request property type to enum",
+      );
+      expect(targetRuleResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if response property added as string+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              responses: {
+                "200": {
+                  description: "",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          data: {
+                            type: "object",
+                            properties: {
+                              attributes: { type: "object", properties: {} },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string", [
+                "ValA",
+                "ValB",
+              ]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const targetRuleResults = results.filter(
+        (r) => r.name === "response property type to enum",
+      );
+      expect(targetRuleResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if request property string to string (no enum)", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("string"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const targetRuleResults = results.filter(
+        (r) => r.name === "request property type to enum",
+      );
+      expect(targetRuleResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if response property string to string (no enum)", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string"),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("string"),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      const targetRuleResults = results.filter(
+        (r) => r.name === "response property type to enum",
+      );
+      expect(targetRuleResults.every((result) => result.passed)).toBe(true);
+      expect(results).toMatchSnapshot();
+    });
+
+    // INTEGER to ENUM tests
+    test("fails if a request property changes from integer to integer+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("integer"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("integer", [1, 2]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "request property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if a response property changes from integer to integer+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("integer"),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("integer", [1, 2]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "response property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("passes if integer to integer+enum in request is experimental", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("integer"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("integer", [1, 2]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context: {
+          ...context,
+          changeVersion: { date: "2021-10-10", stability: "experimental" },
+        },
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => r.name === "request property type to enum" && !r.passed,
+        ).length,
+      ).toBe(0);
+      expect(results).toMatchSnapshot();
+    });
+
+    // NUMBER to ENUM tests
+    test("fails if a request property changes from number to number+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("number"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum(
+                "number",
+                [1.1, 2.2],
+              ),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "request property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if a response property changes from number to number+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("number"),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum(
+                "number",
+                [1.1, 2.2],
+              ),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "response property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    // BOOLEAN to ENUM tests
+    test("fails if a request property changes from boolean to boolean+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("boolean"),
+              responses: {},
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            post: {
+              ...requestBodyWithPropertyTypeAndOptionalEnum("boolean", [true]),
+              responses: {},
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "request property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("fails if a response property changes from boolean to boolean+enum", async () => {
+      const ruleRunner = new RuleRunner([propertyRules]);
+      const beforeSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("boolean"),
+            },
+          },
+        },
+      };
+      const afterSpec: OpenAPIV3.Document = {
+        ...baseOpenAPI,
+        paths: {
+          "/example": {
+            get: {
+              ...responseBodyWithPropertyTypeAndOptionalEnum("boolean", [
+                false,
+              ]),
+            },
+          },
+        },
+      };
+      const ruleInputs = {
+        ...TestHelpers.createRuleInputs(beforeSpec, afterSpec),
+        context,
+      };
+      const results = await ruleRunner.runRulesWithFacts(ruleInputs);
+      expect(
+        results.filter(
+          (r) => !r.passed && r.name === "response property type to enum",
+        ).length,
+      ).toBe(1);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
   describe("disallowAdditionalPropertiesResponse", () => {
     test("fails when additionalProperties is not set to false for new endpoints", async () => {
       const ruleRunner = new RuleRunner([propertyRules]);


### PR DESCRIPTION
This changes introduce a new Rule for validating ENUMs.
The rule considers a breaking change:
- modifying an enum value
- removing an enum value

### Notes for the reviewer
Changing an enum (from string to int for example) will be shown as a breaking change.

Ticket: https://snyksec.atlassian.net/browse/EXT-2655