### PR TITLE
fix: allow property changes when moved to polymorphic branch

### DIFF
--- a/src/rulesets/rest/2022-05-25/property-rules.ts
+++ b/src/rulesets/rest/2022-05-25/property-rules.ts
@@ -11,6 +11,7 @@ import {
   isCompiledOperationSunsetAllowed,
   isResourceMetaProperty,
   isFullyTypedArray,
+  isPropertyMovedToPolymorphicBranch,
   specIsRemoved,
 } from "./utils";
 
@@ -55,8 +56,16 @@ const requestPropertyRemovalRule = {
     ruleContext.operation.change !== "added" &&
     !specIsRemoved(specification) &&
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
-  rule: (requestAssertions) => {
+  rule: (requestAssertions, ruleContext) => {
     requestAssertions.property.removed("not be removed", (property) => {
+      if (
+        isPropertyMovedToPolymorphicBranch(
+          property.location.jsonPath,
+          ruleContext.operation.polymorphicSchemas,
+        )
+      ) {
+        return;
+      }
       throw new RuleError({
         message: `Expected property ${property.value.key} to not be removed`,
       });
@@ -82,8 +91,16 @@ const responsePropertyRemovalRule = {
     ruleContext.operation.change !== "added" &&
     !specIsRemoved(specification) &&
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
-  rule: (responseAssertions) => {
+  rule: (responseAssertions, ruleContext) => {
     responseAssertions.property.removed("not be removed", (property) => {
+      if (
+        isPropertyMovedToPolymorphicBranch(
+          property.location.jsonPath,
+          ruleContext.operation.polymorphicSchemas,
+        )
+      ) {
+        return;
+      }
       throw new RuleError({
         message: `Expected property ${property.value.key} to not be removed`,
       });
@@ -131,10 +148,18 @@ const requiredRequestProperties = new RequestRule({
   matches: (_, ruleContext) =>
     ruleContext.operation.change !== "added" &&
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
-  rule: (requestAssertions) => {
+  rule: (requestAssertions, ruleContext) => {
     requestAssertions.property.added(
       "not add required request property",
       (property) => {
+        if (
+          isPropertyMovedToPolymorphicBranch(
+            property.location.jsonPath,
+            ruleContext.operation.polymorphicSchemas,
+          )
+        ) {
+          return;
+        }
         if (property.value.required) {
           throw new RuleError({
             message:
@@ -405,10 +430,18 @@ const preventChangingRequestType = new RequestRule({
   name: "prevent changing type in request property",
   matches: (_, ruleContext) =>
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
-  rule: (requestAssertions) => {
+  rule: (requestAssertions, ruleContext) => {
     requestAssertions.property.changed(
       "not change the property type",
       (before, after) => {
+        if (
+          isPropertyMovedToPolymorphicBranch(
+            after.location.jsonPath,
+            ruleContext.operation.polymorphicSchemas,
+          )
+        ) {
+          return;
+        }
         const beforeSchema = (before.value.flatSchema ||
           {}) as OpenAPIV3.SchemaObject;
         const afterSchema = (after.value.flatSchema ||
@@ -428,10 +461,18 @@ const preventChangingResponseType = new ResponseBodyRule({
   name: "prevent changing type in request property",
   matches: (_, ruleContext) =>
     !isBreakingChangeAllowed(ruleContext.custom.changeVersion.stability),
-  rule: (responseAssertions) => {
+  rule: (responseAssertions, ruleContext) => {
     responseAssertions.property.changed(
       "not change the property type",
       (before, after) => {
+        if (
+          isPropertyMovedToPolymorphicBranch(
+            after.location.jsonPath,
+            ruleContext.operation.polymorphicSchemas,
+          )
+        ) {
+          return;
+        }
         const beforeSchema = (before.value.flatSchema ||
           {}) as OpenAPIV3.SchemaObject;
         const afterSchema = (after.value.flatSchema ||

--- a/src/rulesets/rest/2022-05-25/utils.ts
+++ b/src/rulesets/rest/2022-05-25/utils.ts
@@ -73,6 +73,38 @@ export const specIsRemoved = (spec): boolean => {
   return spec.change === "removed";
 };
 
+/**
+ * isPropertyMovedToPolymorphicBranch checks whether a property that appears
+ * "removed" actually still exists inside a newly introduced oneOf/anyOf branch.
+ *
+ * When a schema changes from a direct $ref to a oneOf that includes the
+ * original schema, Optic's differ sees the original properties as "removed"
+ * because their JSON paths changed (e.g. from .../attributes/properties/foo
+ * to .../attributes/oneOf/0/properties/foo). This is a false positive.
+ *
+ * We detect this by checking whether any ancestor of the property's path
+ * gained a oneOf/anyOf in the "after" spec that wasn't there in "before".
+ * This covers deeply nested properties too (e.g. attributes/properties/
+ * added_findings/properties/count is still a descendant of attributes).
+ */
+export const isPropertyMovedToPolymorphicBranch = (
+  propertyJsonPath: string,
+  polymorphicSchemas: { before: Set<string>; after: Set<string> },
+): boolean => {
+  for (const afterPath of polymorphicSchemas.after) {
+    if (polymorphicSchemas.before.has(afterPath)) {
+      continue;
+    }
+    if (
+      propertyJsonPath === afterPath ||
+      propertyJsonPath.startsWith(afterPath + "/")
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export const isFullyTypedArray = (
   array: OpenAPIV3.ArraySchemaObject,
 ): boolean => {


### PR DESCRIPTION
_This pull request adds support for detecting when properties are moved to polymorphic branches (oneOf/anyOf) rather than being truly removed._

## Problem

1. Optic dereferences both the "before" (main branch) and "after" (working tree) specs
2. It walks both specs and produces a list of `IFact` objects for each property (fields) it finds
3. If a property path exists in "before" but not in "after", the differ emits a `property.removed` change event
4. Sweater-comb's rules at [property-rules.ts](../../sweater-comb/src/rulesets/rest/2022-05-25/property-rules.ts) react to these events:
    - `responsePropertyRemovalRule` (line 78-92): throws on any `property.removed`
    - `requestPropertyRemovalRule` (line 51-65): same for requests
    - `preventChangingRequestType` (line 404-425): throws when `flatSchema.type` changes
    - `preventChangingResponseType` (line 427-448): same for responses

**What happens with oneOf:**

Before: `attributes` -> `$ref: TestResultsDataAttributes` -> properties: `total_count`, `project_commit_sha`, etc.   
After: `attributes` -> `oneOf: [TestResultsDataAttributes, SecretsTestResultsDataAttributes]`

Optic sees `attributes` as a `oneOf` object now, not an `object` with direct properties. The JSON paths for the properties change from `/properties/data/properties/attributes/properties/total_count` to `/properties/data/properties/attributes/oneOf/0/properties/total_count`. The old paths are gone -> differ says "removed". But they're not removed -- they moved into a `oneOf` branch.

Optic _does_ track `oneOf`/`anyOf` paths via `polymorphicSchemas` on the `EndpointNode` (see [group-facts.ts](../../sweater-comb/node_modules/@useoptic/rulesets-base/src/rule-runner/group-facts.ts) lines 180-210), but **sweater-comb's rules never check this data**. The infrastructure to handle this exists but isn't wired up.

## Solution

The change introduces a new utility function `isPropertyMovedToPolymorphicBranch` that identifies when a property appears "removed" but actually still exists within a newly introduced oneOf/anyOf schema branch. This addresses false positives where Optic's differ incorrectly flags properties as removed when their JSON paths change due to schema restructuring.

The fix is applied to five property validation rules:

- Request property removal validation
- Response property removal validation
- Required request property addition validation
- Request property type change validation
- Response property type change validation

When a property is detected as moved to a polymorphic branch, these rules now skip throwing breaking change errors, preventing false positive violations during API evolution.